### PR TITLE
feat: add titiler link for items

### DIFF
--- a/src/components/stac/value.tsx
+++ b/src/components/stac/value.tsx
@@ -94,6 +94,16 @@ function ValueHeader({ value }: { value: StacValue }) {
               STAC Browser <LuExternalLink></LuExternalLink>
             </a>
           </Button>
+          {value.type == "Feature" && (
+            <Button asChild variant={"surface"} size={"xs"}>
+              <a
+                href={"https://titiler.xyz/stac/viewer?url=" + selfLink.href}
+                target="_blank"
+              >
+                TiTiler <LuExternalLink></LuExternalLink>
+              </a>
+            </Button>
+          )}
         </HStack>
       )}
     </Stack>


### PR DESCRIPTION
Don't love that we're leaking item-specific stuff into `Value`, need to refactor, but it's a quick fix.

cc @vincentsarago 


https://github.com/user-attachments/assets/93517d06-0dc1-4492-9c13-3434472caf92

