### PR TITLE
refactor: invert Value and Item, etc

### DIFF
--- a/src/components/stac/catalog.tsx
+++ b/src/components/stac/catalog.tsx
@@ -1,9 +1,11 @@
+import { Stack } from "@chakra-ui/react";
 import { useEffect } from "react";
 import type { StacCatalog } from "stac-ts";
 import Loading from "../loading";
 import { toaster } from "../ui/toaster";
 import { Collections } from "./collection";
 import { useStacCollections } from "./hooks";
+import Value from "./value";
 
 export default function Catalog({ catalog }: { catalog: StacCatalog }) {
   const { collections, loading, error } = useStacCollections(catalog);
@@ -18,9 +20,13 @@ export default function Catalog({ catalog }: { catalog: StacCatalog }) {
     }
   }, [error]);
 
-  if (loading) {
-    return <Loading></Loading>;
-  } else if (collections) {
-    return <Collections collections={collections}></Collections>;
-  }
+  return (
+    <Stack gap={8}>
+      <Value value={catalog}></Value>
+      {loading && <Loading></Loading>}
+      {!loading && collections && (
+        <Collections collections={collections}></Collections>
+      )}
+    </Stack>
+  );
 }

--- a/src/components/stac/collection.tsx
+++ b/src/components/stac/collection.tsx
@@ -60,7 +60,7 @@ export function Collections({
     return collections.filter((collection) => collectionIds.has(collection.id));
   }, [collectionIds, collections]);
   const [filteredCollections, setFilteredCollections] = useState(collections);
-  const [filterToMapBounds, setFilterToMapBounds] = useState(true);
+  const [filterToMapBounds, setFilterToMapBounds] = useState(false);
   const [bounds, setBounds] = useState<LngLatBounds>();
   const { map } = useMap();
 
@@ -456,5 +456,5 @@ export default function Collection({
     }
   }, [collection, fitBbox]);
 
-  return null;
+  return <Value value={collection}></Value>;
 }

--- a/src/components/stac/item-collection.tsx
+++ b/src/components/stac/item-collection.tsx
@@ -19,6 +19,7 @@ import {
 import { LayersProvider } from "../../providers";
 import Loading from "../loading";
 import { toaster } from "../ui/toaster";
+import Item from "./item";
 import { getItemCollectionLayer } from "./layers";
 import {
   useStacGeoparquet,
@@ -36,17 +37,20 @@ export default function ItemCollection({
   itemCollection: StacItemCollection;
   parquetPath: string | undefined;
 }) {
-  if (parquetPath) {
-    return (
-      <StacGeoparquetItemCollection
-        path={parquetPath}
-      ></StacGeoparquetItemCollection>
-    );
-  } else {
-    return (
-      <JsonItemCollection itemCollection={itemCollection}></JsonItemCollection>
-    );
-  }
+  return (
+    <Stack gap={8}>
+      <Value value={itemCollection}></Value>
+      {(parquetPath && (
+        <StacGeoparquetItemCollection
+          path={parquetPath}
+        ></StacGeoparquetItemCollection>
+      )) || (
+        <JsonItemCollection
+          itemCollection={itemCollection}
+        ></JsonItemCollection>
+      )}
+    </Stack>
+  );
 }
 
 function JsonItemCollection({
@@ -81,7 +85,7 @@ function JsonItemCollection({
         <Card.Header>Selected item</Card.Header>
         <Card.Body>
           <LayersProvider setLayers={undefined}>
-            <Value value={item}></Value>
+            <Item item={item}></Item>
           </LayersProvider>
         </Card.Body>
       </Card.Root>
@@ -250,7 +254,7 @@ function StacGeoparquetItem({ path, id }: { path: string; id: string }) {
         <Card.Root>
           <Card.Header>Selected item</Card.Header>
           <Card.Body>
-            <Value value={item}></Value>
+            <Item item={item}></Item>
           </Card.Body>
         </Card.Root>
       </LayersProvider>

--- a/src/components/stac/item.tsx
+++ b/src/components/stac/item.tsx
@@ -1,10 +1,15 @@
-import { SimpleGrid } from "@chakra-ui/react";
+import { Button, SimpleGrid, Stack } from "@chakra-ui/react";
 import { useEffect } from "react";
+import { LuExternalLink } from "react-icons/lu";
 import type { StacItem } from "stac-ts";
 import { useFitBbox, useLayersDispatch } from "../../hooks";
 import { AssetCard } from "./asset";
 import { getItemLayer } from "./layers";
 import { sanitizeBbox } from "./utils";
+import Value, {
+  SelfLinkButtons as BaseSelfLinkButtons,
+  type SelfLinkButtonsProps,
+} from "./value";
 
 export default function Item({ item }: { item: StacItem }) {
   const dispatch = useLayersDispatch();
@@ -26,10 +31,38 @@ export default function Item({ item }: { item: StacItem }) {
   }, [item, fitBbox]);
 
   return (
-    <SimpleGrid columns={2} gap={2} my={2}>
-      {Object.entries(item.assets).map(([key, asset]) => (
-        <AssetCard key={item.id + key} assetKey={key} asset={asset}></AssetCard>
-      ))}
-    </SimpleGrid>
+    <Stack>
+      <Value
+        value={item}
+        type={"Item"}
+        selfLinkButtonsType={SelfLinkButtons}
+      ></Value>
+
+      <SimpleGrid columns={2} gap={2} my={2}>
+        {Object.entries(item.assets).map(([key, asset]) => (
+          <AssetCard
+            key={item.id + key}
+            assetKey={key}
+            asset={asset}
+          ></AssetCard>
+        ))}
+      </SimpleGrid>
+    </Stack>
+  );
+}
+
+function SelfLinkButtons({ link, children }: SelfLinkButtonsProps) {
+  return (
+    <BaseSelfLinkButtons link={link}>
+      <Button asChild variant={"surface"} size={"xs"}>
+        <a
+          href={"https://titiler.xyz/stac/viewer?url=" + link.href}
+          target="_blank"
+        >
+          TiTiler <LuExternalLink></LuExternalLink>
+        </a>
+      </Button>
+      {children}
+    </BaseSelfLinkButtons>
   );
 }

--- a/src/components/stac/utils.tsx
+++ b/src/components/stac/utils.tsx
@@ -1,6 +1,28 @@
 import { LngLatBounds } from "maplibre-gl";
 import type { StacCollection } from "stac-ts";
-import type { StacItemCollection } from "./types";
+import Catalog from "./catalog";
+import Collection from "./collection";
+import Item from "./item";
+import ItemCollection from "./item-collection";
+import type { StacItemCollection, StacValue } from "./types";
+
+export function getValue(value: StacValue, parquetPath: string | undefined) {
+  switch (value.type) {
+    case "Catalog":
+      return <Catalog catalog={value}></Catalog>;
+    case "Collection":
+      return <Collection collection={value}></Collection>;
+    case "Feature":
+      return <Item item={value}></Item>;
+    case "FeatureCollection":
+      return (
+        <ItemCollection
+          itemCollection={value}
+          parquetPath={parquetPath}
+        ></ItemCollection>
+      );
+  }
+}
 
 export function sanitizeBbox(bbox: number[]) {
   const newBbox = (bbox.length == 6 && [

--- a/src/components/stac/value.tsx
+++ b/src/components/stac/value.tsx
@@ -8,42 +8,22 @@ import {
   Stack,
   Text,
 } from "@chakra-ui/react";
+import type { ComponentType, ReactNode } from "react";
 import { LuExternalLink } from "react-icons/lu";
 import { MarkdownHooks } from "react-markdown";
-import type { StacAsset } from "stac-ts";
+import type { StacAsset, StacLink } from "stac-ts";
 import { Prose } from "../ui/prose";
-import Catalog from "./catalog";
-import Collection from "./collection";
-import Item from "./item";
-import ItemCollection from "./item-collection";
 import type { StacValue } from "./types";
 
 export default function Value({
   value,
-  parquetPath,
+  type,
+  selfLinkButtonsType: SelfLinkButtonsType = SelfLinkButtons,
 }: {
   value: StacValue;
-  parquetPath?: string;
+  type?: string;
+  selfLinkButtonsType?: ComponentType<SelfLinkButtonsProps>;
 }) {
-  return (
-    <Stack position={"relative"} gap={8}>
-      <ValueHeader value={value}></ValueHeader>
-      {value.type === "Catalog" && <Catalog catalog={value}></Catalog>}
-      {value.type === "Collection" && (
-        <Collection collection={value}></Collection>
-      )}
-      {value.type === "Feature" && <Item item={value}></Item>}
-      {value.type === "FeatureCollection" && (
-        <ItemCollection
-          itemCollection={value}
-          parquetPath={parquetPath}
-        ></ItemCollection>
-      )}
-    </Stack>
-  );
-}
-
-function ValueHeader({ value }: { value: StacValue }) {
   const thumbnailAsset =
     typeof value.assets === "object" &&
     value.assets &&
@@ -54,8 +34,9 @@ function ValueHeader({ value }: { value: StacValue }) {
   return (
     <Stack>
       <Text fontSize={"xs"} fontWeight={"lighter"}>
-        {value.type}
+        {type || value.type}
       </Text>
+
       <Heading>{(value.title as string) ?? value.id ?? ""}</Heading>
       {thumbnailAsset && (
         <Image
@@ -64,48 +45,50 @@ function ValueHeader({ value }: { value: StacValue }) {
           fit={"scale-down"}
         ></Image>
       )}
+
       {(value.description as string) && (
         <Prose>
           <MarkdownHooks>{value.description as string}</MarkdownHooks>
         </Prose>
       )}
-      {selfLink && (
-        <HStack>
-          <Clipboard.Root value={selfLink.href}>
-            <Clipboard.Trigger asChild>
-              <IconButton variant="surface" size="xs">
-                <Clipboard.Indicator />
-              </IconButton>
-            </Clipboard.Trigger>
-          </Clipboard.Root>
-          <Button asChild variant={"surface"} size={"xs"}>
-            <a href={selfLink.href} target="_blank">
-              Open <LuExternalLink></LuExternalLink>
-            </a>
-          </Button>
-          <Button asChild variant={"surface"} size={"xs"}>
-            <a
-              href={
-                "https://radiantearth.github.io/stac-browser/#/external/" +
-                selfLink.href.replace(/^(https?:\/\/)/, "")
-              }
-              target="_blank"
-            >
-              STAC Browser <LuExternalLink></LuExternalLink>
-            </a>
-          </Button>
-          {value.type == "Feature" && (
-            <Button asChild variant={"surface"} size={"xs"}>
-              <a
-                href={"https://titiler.xyz/stac/viewer?url=" + selfLink.href}
-                target="_blank"
-              >
-                TiTiler <LuExternalLink></LuExternalLink>
-              </a>
-            </Button>
-          )}
-        </HStack>
-      )}
+
+      {selfLink && <SelfLinkButtonsType link={selfLink}></SelfLinkButtonsType>}
     </Stack>
+  );
+}
+
+export interface SelfLinkButtonsProps {
+  link: StacLink;
+  children?: ReactNode;
+}
+
+export function SelfLinkButtons({ link, children }: SelfLinkButtonsProps) {
+  return (
+    <HStack>
+      <Clipboard.Root value={link.href}>
+        <Clipboard.Trigger asChild>
+          <IconButton variant="surface" size="xs">
+            <Clipboard.Indicator />
+          </IconButton>
+        </Clipboard.Trigger>
+      </Clipboard.Root>
+      <Button asChild variant={"surface"} size={"xs"}>
+        <a href={link.href} target="_blank">
+          Open <LuExternalLink></LuExternalLink>
+        </a>
+      </Button>
+      <Button asChild variant={"surface"} size={"xs"}>
+        <a
+          href={
+            "https://radiantearth.github.io/stac-browser/#/external/" +
+            link.href.replace(/^(https?:\/\/)/, "")
+          }
+          target="_blank"
+        >
+          STAC Browser <LuExternalLink></LuExternalLink>
+        </a>
+      </Button>
+      {children}
+    </HStack>
   );
 }

--- a/src/panel.tsx
+++ b/src/panel.tsx
@@ -1,10 +1,11 @@
-import { Tabs, type UseFileUploadReturn } from "@chakra-ui/react";
+import { Alert, Tabs, type UseFileUploadReturn } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { LuInfo, LuSearch, LuUpload } from "react-icons/lu";
 import Loading from "./components/loading";
 import { useStacValue } from "./components/stac/hooks";
 import Search from "./components/stac/search";
-import Value from "./components/stac/value";
+import type { StacValue } from "./components/stac/types";
+import { getValue } from "./components/stac/utils";
 import { toaster } from "./components/ui/toaster";
 import Upload from "./components/upload";
 import { useLayersDispatch, useSelectedDispatch } from "./hooks";
@@ -66,7 +67,10 @@ export default function Panel({
       <Tabs.ContentGroup overflow={"scroll"} maxH={"80dvh"} px={4} pb={4}>
         <Tabs.Content value="value">
           {(loading && <Loading></Loading>) ||
-            (value && <Value value={value} parquetPath={parquetPath}></Value>)}
+            (value &&
+              (getValue(value, parquetPath) || (
+                <InvalidStacValue href={href} value={value}></InvalidStacValue>
+              )))}
         </Tabs.Content>
         <Tabs.Content value="search">
           {value && <Search href={href} value={value}></Search>}
@@ -76,5 +80,19 @@ export default function Panel({
         </Tabs.Content>
       </Tabs.ContentGroup>
     </Tabs.Root>
+  );
+}
+
+function InvalidStacValue({ href, value }: { href: string; value: StacValue }) {
+  return (
+    <Alert.Root status={"error"}>
+      <Alert.Indicator></Alert.Indicator>
+      <Alert.Content>
+        <Alert.Title>Invalid STAC value</Alert.Title>
+        <Alert.Description>
+          STAC value at {href} has an invalid type field: {value.type}
+        </Alert.Description>
+      </Alert.Content>
+    </Alert.Root>
   );
 }


### PR DESCRIPTION
When I added the TiTiler button, we leaked StacValue type information into a place it shouldn't have been. This inversion fixes that.

This _might_ help us remove the layer dispatch magic in the future, in the sense that we could add a "display=false" prop to `Item`, etc to tell the component to not render itself (or maybe control rendering? not sure yet ...)