### PR TITLE
feat: date filter

### DIFF
--- a/src/components/search/item.tsx
+++ b/src/components/search/item.tsx
@@ -4,9 +4,12 @@ import {
   Button,
   ButtonGroup,
   createListCollection,
+  Field,
+  Group,
   Heading,
   HStack,
   IconButton,
+  Input,
   Portal,
   Progress,
   Select,
@@ -14,10 +17,11 @@ import {
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { LuPause, LuPlay, LuSearch, LuX } from "react-icons/lu";
-import type { StacCollection, StacLink } from "stac-ts";
+import type { StacCollection, StacLink, TemporalExtent } from "stac-ts";
 import useStacMap from "../../hooks/stac-map";
 import useStacSearch from "../../hooks/stac-search";
 import type { StacSearch } from "../../types/stac";
+import { toaster } from "../ui/toaster";
 
 export default function ItemSearch({
   collection,
@@ -29,6 +33,7 @@ export default function ItemSearch({
   const { setItems, setPicked } = useStacMap();
   const [search, setSearch] = useState<StacSearch>();
   const [link, setLink] = useState<StacLink | undefined>(links[0]);
+  const [datetime, setDatetime] = useState<string>();
 
   useEffect(() => {
     if (!search) {
@@ -60,6 +65,11 @@ export default function ItemSearch({
           </Alert.Description>
         </Alert.Content>
       </Alert.Root>
+
+      <Datetime
+        interval={collection.extent?.temporal?.interval[0]}
+        setDatetime={setDatetime}
+      ></Datetime>
 
       <HStack>
         <Box flex={1}></Box>
@@ -98,7 +108,7 @@ export default function ItemSearch({
 
         <Button
           variant={"surface"}
-          onClick={() => setSearch({ collections: [collection.id] })}
+          onClick={() => setSearch({ collections: [collection.id], datetime })}
           disabled={!!search}
         >
           <LuSearch></LuSearch>
@@ -127,7 +137,7 @@ function Results({
   doClear: () => void;
 }) {
   const { items, setItems } = useStacMap();
-  const { data, isFetchingNextPage, hasNextPage, fetchNextPage } =
+  const { data, isFetchingNextPage, hasNextPage, fetchNextPage, error } =
     useStacSearch(search, link);
   const [pause, setPause] = useState(false);
 
@@ -140,6 +150,17 @@ function Results({
       fetchNextPage();
     }
   }, [isFetchingNextPage, pause, hasNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    if (error) {
+      toaster.create({
+        type: "error",
+        title: "Search error",
+        description: error.toString(),
+      });
+      doClear();
+    }
+  }, [error, doClear]);
 
   return (
     <Progress.Root
@@ -176,5 +197,127 @@ function Results({
         </Progress.ValueText>
       </HStack>
     </Progress.Root>
+  );
+}
+
+function Datetime({
+  interval,
+  setDatetime,
+}: {
+  interval: TemporalExtent | undefined;
+  setDatetime: (datetime: string | undefined) => void;
+}) {
+  const [startDatetime, setStartDatetime] = useState(
+    interval?.[0] ? new Date(interval[0]) : undefined,
+  );
+  const [endDatetime, setEndDatetime] = useState(
+    interval?.[1] ? new Date(interval[1]) : undefined,
+  );
+
+  useEffect(() => {
+    if (startDatetime || endDatetime) {
+      setDatetime(
+        `${startDatetime?.toISOString() || ".."}/${endDatetime?.toISOString() || ".."}`,
+      );
+    } else {
+      setDatetime(undefined);
+    }
+  }, [startDatetime, endDatetime, setDatetime]);
+
+  return (
+    <Stack>
+      <DatetimeInput
+        label="Start datetime"
+        datetime={startDatetime}
+        setDatetime={setStartDatetime}
+      ></DatetimeInput>
+      <DatetimeInput
+        label="End datetime"
+        datetime={endDatetime}
+        setDatetime={setEndDatetime}
+      ></DatetimeInput>
+      <HStack>
+        <Button
+          variant={"outline"}
+          onClick={() => {
+            setStartDatetime(interval?.[0] ? new Date(interval[0]) : undefined);
+            setEndDatetime(interval?.[1] ? new Date(interval[1]) : undefined);
+          }}
+        >
+          Set to collection extents
+        </Button>
+      </HStack>
+    </Stack>
+  );
+}
+
+function DatetimeInput({
+  label,
+  datetime,
+  setDatetime,
+}: {
+  label: string;
+  datetime: Date | undefined;
+  setDatetime: (datetime: Date | undefined) => void;
+}) {
+  const [error, setError] = useState<string>();
+  const dateValue = datetime?.toISOString().split("T")[0] || "";
+  const timeValue = datetime?.toISOString().split("T")[1].slice(0, 8) || "";
+
+  const setDatetimeChecked = (datetime: Date) => {
+    try {
+      datetime.toISOString();
+      // eslint-disable-next-line
+    } catch (e: any) {
+      setError(e.toString());
+      return;
+    }
+    setDatetime(datetime);
+    setError(undefined);
+  };
+  const setDate = (date: string) => {
+    setDatetimeChecked(
+      new Date(date + "T" + (timeValue == "" ? "00:00:00" : timeValue) + "Z"),
+    );
+  };
+  const setTime = (time: string) => {
+    if (dateValue != "") {
+      const newDatetime = new Date(dateValue);
+      const timeParts = time.split(":").map(Number);
+      newDatetime.setUTCHours(timeParts[0]);
+      newDatetime.setUTCMinutes(timeParts[1]);
+      if (timeParts.length == 3) {
+        newDatetime.setUTCSeconds(timeParts[2]);
+      }
+      setDatetimeChecked(newDatetime);
+    }
+  };
+
+  return (
+    <Field.Root invalid={!!error}>
+      <Field.Label>{label}</Field.Label>
+      <Group attached w={"full"}>
+        <Input
+          type="date"
+          value={dateValue}
+          onChange={(e) => setDate(e.target.value)}
+          size={"sm"}
+        ></Input>
+        <Input
+          type="time"
+          value={timeValue}
+          onChange={(e) => setTime(e.target.value)}
+          size={"sm"}
+        ></Input>
+        <IconButton
+          size={"sm"}
+          variant={"outline"}
+          onClick={() => setDatetime(undefined)}
+        >
+          <LuX></LuX>
+        </IconButton>
+      </Group>
+      <Field.ErrorText>{error}</Field.ErrorText>
+    </Field.Root>
   );
 }

--- a/src/hooks/stac-search.ts
+++ b/src/hooks/stac-search.ts
@@ -20,12 +20,13 @@ async function fetchSearch({ pageParam }: { pageParam: StacLink }) {
       "Content-type": "application/json",
     },
     body: (pageParam.body as StacSearch) && JSON.stringify(pageParam.body),
-  }).then((response) => {
+  }).then(async (response) => {
     if (response.ok) {
       return response.json();
     } else {
+      const text = await response.text();
       throw new Error(
-        `Could not ${pageParam.method || "GET"} ${pageParam.href}: ${response.statusText}`,
+        `Could not ${pageParam.method || "GET"} ${pageParam.href}: ${response.statusText}: ${text}`,
       );
     }
   });
@@ -39,6 +40,9 @@ function updateLink(link: StacLink, search: StacSearch) {
   if (link.method == "GET") {
     if (search.collections) {
       url.searchParams.set("collections", search.collections.join(","));
+    }
+    if (search.datetime) {
+      url.searchParams.set("datetime", search.datetime);
     }
   } else {
     link.body = search;

--- a/src/types/stac.d.ts
+++ b/src/types/stac.d.ts
@@ -25,6 +25,7 @@ export interface StacCollections {
 
 export interface StacSearch {
   collections?: string[];
+  datetime?: string;
   bbox?: number[];
   limit?: number;
 }


### PR DESCRIPTION
A simple search date filter. Cribbed from https://github.com/developmentseed/stac-map/pull/60 but updated for some refactors (so you don't have to unpick what I did in the refactors).

https://github.com/user-attachments/assets/68c804db-1b65-442f-b2bc-707e9a5bc67f

Some changes, curious what you think:

- I'm keeping the filter out of the URL for now. I'm still not _sure_ we want the same date filter for search as we do for the "filters" tab. We can always add it back to the url later
- I removed the pre-set buttons. While they make sense for some collections, there's a lot of archive collections that they don't make sense for? Curious what you think...