### PR TITLE
feat: search w/i bounds

### DIFF
--- a/src/components/search/item.tsx
+++ b/src/components/search/item.tsx
@@ -14,9 +14,12 @@ import {
   Progress,
   Select,
   Stack,
+  Switch,
+  Text,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { LuPause, LuPlay, LuSearch, LuX } from "react-icons/lu";
+import { useMap } from "react-map-gl/maplibre";
 import type { StacCollection, StacLink, TemporalExtent } from "stac-ts";
 import useStacMap from "../../hooks/stac-map";
 import useStacSearch from "../../hooks/stac-search";
@@ -34,6 +37,8 @@ export default function ItemSearch({
   const [search, setSearch] = useState<StacSearch>();
   const [link, setLink] = useState<StacLink | undefined>(links[0]);
   const [datetime, setDatetime] = useState<string>();
+  const [useViewportBounds, setUseViewportBounds] = useState(true);
+  const { map } = useMap();
 
   useEffect(() => {
     if (!search) {
@@ -65,6 +70,17 @@ export default function ItemSearch({
           </Alert.Description>
         </Alert.Content>
       </Alert.Root>
+
+      <Switch.Root
+        checked={useViewportBounds}
+        onCheckedChange={(e) => setUseViewportBounds(e.checked)}
+      >
+        <Switch.HiddenInput></Switch.HiddenInput>
+        <Switch.Label>Use viewport bounds</Switch.Label>
+        <Switch.Control></Switch.Control>
+      </Switch.Root>
+
+      <Text></Text>
 
       <Datetime
         interval={collection.extent?.temporal?.interval[0]}
@@ -108,7 +124,16 @@ export default function ItemSearch({
 
         <Button
           variant={"surface"}
-          onClick={() => setSearch({ collections: [collection.id], datetime })}
+          onClick={() =>
+            setSearch({
+              collections: [collection.id],
+              datetime,
+              bbox:
+                useViewportBounds && map
+                  ? map.getBounds().toArray().flat()
+                  : undefined,
+            })
+          }
           disabled={!!search}
         >
           <LuSearch></LuSearch>

--- a/src/components/search/item.tsx
+++ b/src/components/search/item.tsx
@@ -72,7 +72,8 @@ export default function ItemSearch({
       </Alert.Root>
 
       <Switch.Root
-        checked={useViewportBounds}
+        disabled={!map}
+        checked={!!map && useViewportBounds}
         onCheckedChange={(e) => setUseViewportBounds(e.checked)}
       >
         <Switch.HiddenInput></Switch.HiddenInput>

--- a/src/hooks/stac-search.ts
+++ b/src/hooks/stac-search.ts
@@ -41,6 +41,9 @@ function updateLink(link: StacLink, search: StacSearch) {
     if (search.collections) {
       url.searchParams.set("collections", search.collections.join(","));
     }
+    if (search.bbox) {
+      url.searchParams.set("bbox", search.bbox.join(","));
+    }
     if (search.datetime) {
       url.searchParams.set("datetime", search.datetime);
     }


### PR DESCRIPTION
A little simpler, because we use `useMap` instead of pushing it up into state.

Closes https://github.com/developmentseed/stac-map/pull/61 as OBE.