### PR TITLE
feat: filtering

### DIFF
--- a/src/components/filter.tsx
+++ b/src/components/filter.tsx
@@ -1,0 +1,88 @@
+import {
+  Center,
+  DataList,
+  Heading,
+  Slider,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import useStacMap from "../hooks/stac-map";
+
+export default function Filter({
+  temporalExtents,
+}: {
+  temporalExtents: { start: Date; end: Date };
+}) {
+  const [start, setStart] = useState<number>();
+  const [end, setEnd] = useState<number>();
+  const { setTemporalFilter } = useStacMap();
+
+  useEffect(() => {
+    if (start !== undefined && end !== undefined) {
+      setTemporalFilter({
+        start: new Date(temporalExtents.start.getTime() + start * 1000),
+        end: new Date(temporalExtents.start.getTime() + end * 1000),
+      });
+    }
+  }, [temporalExtents, setTemporalFilter, start, end]);
+
+  return (
+    <Stack gap={4}>
+      <Heading>Temporal extents</Heading>
+      <DataList.Root orientation={"horizontal"}>
+        <DataList.Item>
+          <DataList.ItemLabel>Start</DataList.ItemLabel>
+          <DataList.ItemValue>
+            {temporalExtents.start.toLocaleString()}
+          </DataList.ItemValue>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.ItemLabel>End</DataList.ItemLabel>
+          <DataList.ItemValue>
+            {temporalExtents.end.toLocaleString()}
+          </DataList.ItemValue>
+        </DataList.Item>
+      </DataList.Root>
+
+      <Slider.Root
+        min={0}
+        max={
+          (temporalExtents.end.getTime() - temporalExtents.start.getTime()) /
+          1000
+        }
+        value={[
+          start || 0,
+          end ||
+            (temporalExtents.end.getTime() - temporalExtents.start.getTime()) /
+              1000,
+        ]}
+        onValueChange={(e) => {
+          setStart(e.value[0]);
+          setEnd(e.value[1]);
+        }}
+      >
+        <Slider.Label>Temporal filter</Slider.Label>
+        <Slider.Control>
+          <Slider.Track>
+            <Slider.Range></Slider.Range>
+          </Slider.Track>
+          <Slider.Thumbs></Slider.Thumbs>
+        </Slider.Control>
+      </Slider.Root>
+      {start !== undefined && end !== undefined && (
+        <Center>
+          <Text fontSize={"xs"}>
+            {new Date(
+              temporalExtents.start.getTime() + start * 1000,
+            ).toLocaleString()}{" "}
+            to{" "}
+            {new Date(
+              temporalExtents.start.getTime() + end * 1000,
+            ).toLocaleString()}
+          </Text>
+        </Center>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -19,7 +19,7 @@ import {
   useControl,
   type MapRef,
 } from "react-map-gl/maplibre";
-import type { StacCollection } from "stac-ts";
+import type { StacCollection, StacItem } from "stac-ts";
 import useStacMap from "../hooks/stac-map";
 import type { StacValue } from "../types/stac";
 import { useColorModeValue } from "./ui/color-mode";
@@ -55,6 +55,7 @@ export default function Map() {
     stacGeoparquetTable,
     stacGeoparquetMetadata,
     setStacGeoparquetItemId,
+    temporalFilter,
   } = useStacMap();
   const {
     geojson,
@@ -63,6 +64,7 @@ export default function Map() {
   } = useStacValueLayerProperties(value, collections);
   const [bbox, setBbox] = useState<BBox>();
   const small = useBreakpointValue({ base: true, md: false });
+  const [filteredItems, setFilteredItems] = useState<StacItem[]>();
 
   useEffect(() => {
     if (valueBbox) {
@@ -75,6 +77,31 @@ export default function Map() {
       setBbox(stacGeoparquetMetadata.bbox);
     }
   }, [stacGeoparquetMetadata]);
+
+  useEffect(() => {
+    if (items) {
+      if (temporalFilter) {
+        setFilteredItems(
+          items.filter((item) => {
+            const startStr =
+              item.properties.start_datetime || item.properties.datetime;
+            const start = startStr ? new Date(startStr) : null;
+            const endStr =
+              item.properties.end_datetime || item.properties.datetime;
+            const end = endStr ? new Date(endStr) : null;
+            return (
+              (!start || start >= temporalFilter.start) &&
+              (!end || end <= temporalFilter.end)
+            );
+          }),
+        );
+      } else {
+        setFilteredItems(items);
+      }
+    } else {
+      setFilteredItems(undefined);
+    }
+  }, [items, temporalFilter]);
 
   useEffect(() => {
     if (bbox && mapRef.current) {
@@ -111,7 +138,7 @@ export default function Map() {
     }),
     new GeoJsonLayer({
       id: "items",
-      data: items as Feature[] | undefined,
+      data: filteredItems as Feature[] | undefined,
       filled: true,
       stroked: true,
       getFillColor: fillColor,

--- a/src/components/panel.tsx
+++ b/src/components/panel.tsx
@@ -1,6 +1,7 @@
 import { SkeletonText, Tabs } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import {
+  LuFilter,
   LuInfo,
   LuMousePointerClick,
   LuSearch,
@@ -9,13 +10,14 @@ import {
 import type { StacLink } from "stac-ts";
 import useStacMap from "../hooks/stac-map";
 import useStacValue from "../hooks/stac-value";
+import Filter from "./filter";
 import ItemSearch from "./search/item";
 import { NaturalLanguageCollectionSearch } from "./search/natural-language";
 import Upload from "./upload";
 import Value from "./value";
 
 export default function Panel() {
-  const { href, value, picked, collections } = useStacMap();
+  const { href, value, picked, collections, temporalExtents } = useStacMap();
   const [tab, setTab] = useState<string>("upload");
   const [search, setSearch] = useState(false);
   const [catalogHref, setCatalogHref] = useState<string>();
@@ -76,6 +78,9 @@ export default function Panel() {
         <Tabs.Trigger value="search" disabled={!search}>
           <LuSearch></LuSearch>
         </Tabs.Trigger>
+        <Tabs.Trigger value="filter" disabled={!temporalExtents}>
+          <LuFilter></LuFilter>
+        </Tabs.Trigger>
         <Tabs.Trigger value="picked" disabled={!picked}>
           <LuMousePointerClick></LuMousePointerClick>
         </Tabs.Trigger>
@@ -103,6 +108,11 @@ export default function Panel() {
           )}
           {searchLinks && value && value.type == "Collection" && (
             <ItemSearch collection={value} links={searchLinks}></ItemSearch>
+          )}
+        </Tabs.Content>
+        <Tabs.Content value="filter">
+          {temporalExtents && (
+            <Filter temporalExtents={temporalExtents}></Filter>
           )}
         </Tabs.Content>
         <Tabs.Content value="picked">

--- a/src/context.ts
+++ b/src/context.ts
@@ -50,4 +50,15 @@ interface StacMapContextType {
   /// Set the id of a stac-geoparquet item that should be fetched from the
   /// parquet table and loaded into the picked item.
   setStacGeoparquetItemId: (id: string | undefined) => void;
+
+  /// The temporal extents of the loaded data.
+  temporalExtents: { start: Date; end: Date } | undefined;
+
+  /// The start and end datetimes of the temporal filter.
+  temporalFilter: { start: Date; end: Date } | undefined;
+
+  /// Sets the temporal filter.
+  setTemporalFilter: (
+    temporalFilter: { start: Date; end: Date } | undefined,
+  ) => void;
 }

--- a/src/hooks/stac-geoparquet.ts
+++ b/src/hooks/stac-geoparquet.ts
@@ -14,17 +14,21 @@ import { useEffect, useState } from "react";
 import * as stacWasm from "../stac-wasm";
 import type { StacGeoparquetMetadata } from "../types/stac";
 
-export default function useStacGeoparquet(path: string | undefined) {
+export default function useStacGeoparquet(
+  path: string | undefined,
+  temporalFilter: { start: Date; end: Date } | undefined,
+) {
   const [id, setId] = useState<string>();
   const { db } = useDuckDb();
   const [connection, setConnection] = useState<AsyncDuckDBConnection>();
   const { data: table } = useQuery({
-    queryKey: ["stac-geoparquet-table", path],
+    queryKey: ["stac-geoparquet-table", path, temporalFilter],
     queryFn: async () => {
       if (path && connection) {
-        return await getTable(path, connection);
+        return await getTable(path, connection, temporalFilter);
       }
     },
+    placeholderData: (previousData) => previousData,
     enabled: !!(connection && path),
   });
   const { data: metadata } = useQuery({
@@ -59,10 +63,30 @@ export default function useStacGeoparquet(path: string | undefined) {
   return { table, metadata, item, setId };
 }
 
-async function getTable(path: string, connection: AsyncDuckDBConnection) {
-  const result = await connection.query(
-    `SELECT ST_AsWKB(geometry) as geometry, id FROM read_parquet('${path}')`,
-  );
+async function getTable(
+  path: string,
+  connection: AsyncDuckDBConnection,
+  temporalFilter: { start: Date; end: Date } | undefined,
+) {
+  let query = `SELECT ST_AsWKB(geometry) as geometry, id FROM read_parquet('${path}')`;
+  if (temporalFilter) {
+    const describeResult = await connection.query(
+      `DESCRIBE SELECT * FROM read_parquet('${path}')`,
+    );
+    const columnNames = describeResult
+      .toArray()
+      .map((row) => row.toJSON().column_name);
+    const startDatetimeColumnName = columnNames.includes("start_datetime")
+      ? "start_datetime"
+      : "datetime";
+    const endDatetimeColumnName = columnNames.includes("end_datetime")
+      ? "start_datetime"
+      : "datetime";
+
+    query += ` WHERE ${startDatetimeColumnName} >= DATETIME '${temporalFilter.start.toISOString()}'  AND ${endDatetimeColumnName} <= DATETIME '${temporalFilter.end.toISOString()}'`;
+  }
+
+  const result = await connection.query(query);
   const geometry: Uint8Array[] = result.getChildAt(0)?.toArray();
   const wkb = new Uint8Array(geometry?.flatMap((array) => [...array]));
   const valueOffsets = new Int32Array(geometry.length + 1);
@@ -92,8 +116,21 @@ async function getMetadata(
   path: string,
   connection: AsyncDuckDBConnection,
 ): Promise<StacGeoparquetMetadata> {
+  const describeResult = await connection.query(
+    `DESCRIBE SELECT * FROM read_parquet('${path}')`,
+  );
+  const columnNames = describeResult
+    .toArray()
+    .map((row) => row.toJSON().column_name);
+  const startDatetimeColumnName = columnNames.includes("start_datetime")
+    ? "start_datetime"
+    : "datetime";
+  const endDatetimeColumnName = columnNames.includes("end_datetime")
+    ? "start_datetime"
+    : "datetime";
+
   const summaryResult = await connection.query(
-    `SELECT COUNT(*) as count, MIN(bbox.xmin) as xmin, MIN(bbox.ymin) as ymin, MAX(bbox.xmax) as xmax, MAX(bbox.ymax) as ymax FROM read_parquet('${path}')`,
+    `SELECT COUNT(*) as count, MIN(bbox.xmin) as xmin, MIN(bbox.ymin) as ymin, MAX(bbox.xmax) as xmax, MAX(bbox.ymax) as ymax, MIN(${startDatetimeColumnName}) as start_datetime, MAX(${endDatetimeColumnName}) as end_datetime FROM read_parquet('${path}')`,
   );
   const summaryRow = summaryResult.toArray().map((row) => row.toJSON())[0];
 
@@ -120,6 +157,12 @@ async function getMetadata(
     count: summaryRow.count,
     bbox: [summaryRow.xmin, summaryRow.ymin, summaryRow.xmax, summaryRow.ymax],
     keyValue: kvMetadata,
+    startDatetime: summaryRow.start_datetime
+      ? new Date(summaryRow.start_datetime)
+      : null,
+    endDatetime: summaryRow.end_datetime
+      ? new Date(summaryRow.end_datetime)
+      : null,
   };
 }
 

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -12,13 +12,21 @@ export function StacMapProvider({ children }: { children: ReactNode }) {
   const { value, parquetPath } = useStacValue(href, fileUpload);
   const collections = useStacCollections(value);
   const [items, setItems] = useState<StacItem[]>();
+  const [temporalFilter, setTemporalFilter] = useState<{
+    start: Date;
+    end: Date;
+  }>();
   const {
     table: stacGeoparquetTable,
     metadata: stacGeoparquetMetadata,
     setId: setStacGeoparquetItemId,
     item: stacGeoparquetItem,
-  } = useStacGeoparquet(parquetPath);
+  } = useStacGeoparquet(parquetPath, temporalFilter);
   const [picked, setPicked] = useState<StacItem>();
+  const [temporalExtents, setTemporalExtents] = useState<{
+    start: Date;
+    end: Date;
+  }>();
 
   useEffect(() => {
     function handlePopState() {
@@ -47,6 +55,53 @@ export function StacMapProvider({ children }: { children: ReactNode }) {
   }, [fileUpload.acceptedFiles]);
 
   useEffect(() => {
+    setItems(undefined);
+    setPicked(undefined);
+    setStacGeoparquetItemId(undefined);
+    setTemporalExtents(undefined);
+    setTemporalFilter(undefined);
+  }, [value, setStacGeoparquetItemId]);
+
+  useEffect(() => {
+    if (items) {
+      let start: Date | null = null;
+      let end: Date | null = null;
+      items.forEach((item) => {
+        const itemStartStr =
+          item.properties.start_datetime || item.properties.datetime;
+        const itemStart = itemStartStr ? new Date(itemStartStr) : null;
+        if (!start || (itemStart && itemStart < start)) {
+          start = itemStart;
+        }
+        const itemEndStr =
+          item.properties.end_datetime || item.properties.datetime;
+        const itemEnd = itemEndStr ? new Date(itemEndStr) : null;
+        if (!end || (itemEnd && itemEnd > end)) {
+          end = itemEnd;
+        }
+      });
+      if (start && end) {
+        setTemporalExtents({ start, end });
+      }
+    }
+  }, [items]);
+
+  useEffect(() => {
+    if (
+      stacGeoparquetMetadata?.startDatetime &&
+      stacGeoparquetMetadata?.endDatetime
+    ) {
+      setTemporalExtents({
+        start: stacGeoparquetMetadata.startDatetime,
+        end: stacGeoparquetMetadata.endDatetime,
+      });
+    }
+  }, [
+    stacGeoparquetMetadata?.startDatetime,
+    stacGeoparquetMetadata?.endDatetime,
+  ]);
+
+  useEffect(() => {
     setPicked(stacGeoparquetItem);
   }, [stacGeoparquetItem]);
 
@@ -65,6 +120,9 @@ export function StacMapProvider({ children }: { children: ReactNode }) {
         stacGeoparquetTable,
         stacGeoparquetMetadata,
         setStacGeoparquetItemId,
+        temporalExtents,
+        temporalFilter,
+        setTemporalFilter,
       }}
     >
       {children}

--- a/src/types/stac.d.ts
+++ b/src/types/stac.d.ts
@@ -39,6 +39,8 @@ export interface StacGeoparquetMetadata {
   count: number;
   bbox: BBox;
   keyValue: KeyValueMetadata[];
+  startDatetime: Date | null;
+  endDatetime: Date | null;
 }
 
 export interface KeyValueMetadata {


### PR DESCRIPTION
@indraneel I took a read through https://github.com/developmentseed/stac-map/pull/60 again and tried a straight merge, but I've refactored enough that the merge resolution was going to be a PITA. Instead, I took out most of the filtering stuff and put it onto the **items** branch manually. I stripped down some of the formatting/layout, but can add back stuff that you think would help. Here's the video:

https://github.com/user-attachments/assets/d9f6e393-5992-4390-ad4e-0f4ab656883f

One enhancement is using either `start|end_datetime` or `datetime`, depending on what's present in the **stac-geoparquet**.