### PR TITLE
fix: search over antimeridian

### DIFF
--- a/src/components/search/item.tsx
+++ b/src/components/search/item.tsx
@@ -15,7 +15,6 @@ import {
   Select,
   Stack,
   Switch,
-  Text,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { LuPause, LuPlay, LuSearch, LuX } from "react-icons/lu";
@@ -81,8 +80,6 @@ export default function ItemSearch({
         <Switch.Control></Switch.Control>
       </Switch.Root>
 
-      <Text></Text>
-
       <Datetime
         interval={collection.extent?.temporal?.interval[0]}
         setDatetime={setDatetime}
@@ -131,7 +128,7 @@ export default function ItemSearch({
               datetime,
               bbox:
                 useViewportBounds && map
-                  ? map.getBounds().toArray().flat()
+                  ? normalizeBbox(map.getBounds().toArray().flat())
                   : undefined,
             })
           }
@@ -354,4 +351,27 @@ function DatetimeInput({
       <Field.ErrorText>{error}</Field.ErrorText>
     </Field.Root>
   );
+}
+
+function normalizeBbox(bbox: [number, number, number, number]) {
+  if (bbox[2] - bbox[0] >= 360) {
+    return [-180, bbox[1], 180, bbox[3]];
+  } else if (bbox[0] < -180) {
+    return normalizeBbox([bbox[0] + 360, bbox[1], bbox[2] + 360, bbox[3]]);
+  } else if (bbox[0] > 180) {
+    return normalizeBbox([bbox[0] - 360, bbox[1], bbox[2] - 360, bbox[3]]);
+  } else if (bbox[2] > 180) {
+    // Antimeridian-crossing
+    toaster.create({
+      type: "info",
+      title: "Viewport crosses the antimeridian",
+      description:
+        "The viewport crosses the antimeridian, and many STAC API servers do not support bounding boxes that cross +/- 180° longitude. We're narrowing the viewport to only search to only one side.",
+    });
+    if ((bbox[0] + bbox[2]) / 2 > 180) {
+      return [-180, bbox[1], bbox[2] - 360, bbox[3]];
+    } else {
+      return [bbox[0], bbox[1], 180, bbox[3]];
+    }
+  }
 }

--- a/src/components/search/item.tsx
+++ b/src/components/search/item.tsx
@@ -34,7 +34,7 @@ export default function ItemSearch({
   collection: StacCollection;
   links: StacLink[];
 }) {
-  const { setItems, setPicked } = useStacMap();
+  const { setItems } = useStacMap();
   const [search, setSearch] = useState<StacSearch>();
   const [link, setLink] = useState<StacLink | undefined>(links[0]);
   const [datetime, setDatetime] = useState<string>();
@@ -44,9 +44,8 @@ export default function ItemSearch({
   useEffect(() => {
     if (!search) {
       setItems(undefined);
-      setPicked(undefined);
     }
-  }, [search, setItems, setPicked]);
+  }, [search, setItems]);
 
   const methods = createListCollection({
     items: links.map((link) => {

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -64,6 +64,10 @@ export function StacMapProvider({ children }: { children: ReactNode }) {
   }, [value, setStacGeoparquetItemId]);
 
   useEffect(() => {
+    setPicked(undefined);
+  }, [items]);
+
+  useEffect(() => {
     if (items) {
       let start: Date | null = null;
       let end: Date | null = null;

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -72,15 +72,10 @@ export function StacMapProvider({ children }: { children: ReactNode }) {
       let start: Date | null = null;
       let end: Date | null = null;
       items.forEach((item) => {
-        const itemStartStr =
-          item.properties.start_datetime || item.properties.datetime;
-        const itemStart = itemStartStr ? new Date(itemStartStr) : null;
+        const { start: itemStart, end: itemEnd } = getStartAndEndDatetime(item);
         if (!start || (itemStart && itemStart < start)) {
           start = itemStart;
         }
-        const itemEndStr =
-          item.properties.end_datetime || item.properties.datetime;
-        const itemEnd = itemEndStr ? new Date(itemEndStr) : null;
         if (!end || (itemEnd && itemEnd > end)) {
           end = itemEnd;
         }
@@ -96,12 +91,7 @@ export function StacMapProvider({ children }: { children: ReactNode }) {
       if (temporalFilter) {
         setFilteredItems(
           items.filter((item) => {
-            const startStr =
-              item.properties.start_datetime || item.properties.datetime;
-            const start = startStr ? new Date(startStr) : null;
-            const endStr =
-              item.properties.end_datetime || item.properties.datetime;
-            const end = endStr ? new Date(endStr) : null;
+            const { start, end } = getStartAndEndDatetime(item);
             return (
               (!start || start >= temporalFilter.start) &&
               (!end || end <= temporalFilter.end)
@@ -168,4 +158,12 @@ function getInitialHref() {
     return undefined;
   }
   return href;
+}
+
+function getStartAndEndDatetime(item: StacItem) {
+  const startStr = item.properties.start_datetime || item.properties.datetime;
+  const start = startStr ? new Date(startStr) : null;
+  const endStr = item.properties.end_datetime || item.properties.datetime;
+  const end = endStr ? new Date(endStr) : null;
+  return { start, end };
 }


### PR DESCRIPTION
The only "feature degredation" that we do is choosing only one side of the antimeridian to search (while warning the user). To robustly search on both sides, we'd either need to split into two searches _or_ search on a multipolygon, both of which are possible but more complex. I'll open a tracking ticket to support searching both sides of the antimeridian.

Includes some light refactoring I did while driving by.

https://github.com/user-attachments/assets/e07e0005-d2f9-4da7-90dc-85280b8143f5

