### PR TITLE
feat: rework breadcrumbs

### DIFF
--- a/src/components/catalog.tsx
+++ b/src/components/catalog.tsx
@@ -1,5 +1,25 @@
+import { SkeletonText, Stack } from "@chakra-ui/react";
 import type { StacCatalog } from "stac-ts";
+import useStacMap from "../hooks/stac-map";
 import { ChildCard, Children } from "./children";
+import { Collections } from "./collection";
+import Value from "./value";
+
+export function Catalog({ catalog }: { catalog: StacCatalog }) {
+  const { catalogs, collections, isFetchingCollections } = useStacMap();
+  return (
+    <Stack>
+      <Value value={catalog}></Value>
+      {catalogs && catalogs.length > 0 && (
+        <Catalogs catalogs={catalogs}></Catalogs>
+      )}
+      {(collections && collections.length > 0 && (
+        <Collections collections={collections}></Collections>
+      )) ||
+        (isFetchingCollections && <SkeletonText noOfLines={3}></SkeletonText>)}
+    </Stack>
+  );
+}
 
 export function Catalogs({ catalogs }: { catalogs: StacCatalog[] }) {
   return (

--- a/src/components/collection.tsx
+++ b/src/components/collection.tsx
@@ -15,32 +15,45 @@ import type {
 import useStacMap from "../hooks/stac-map";
 import { ChildCard, Children } from "./children";
 import { CollectionCombobox } from "./search/collection";
+import ItemSearch from "./search/item";
 import { NaturalLanguageCollectionSearch } from "./search/natural-language";
+import Value from "./value";
 
 export function Collection({ collection }: { collection: StacCollection }) {
+  const { root } = useStacMap();
+  const searchLinks =
+    (root && root.links?.filter((link) => link.rel == "search")) || [];
+  console.log(searchLinks);
   return (
-    <DataList.Root orientation={"horizontal"} size={"sm"} py={4}>
-      {collection.extent?.spatial?.bbox?.[0] && (
-        <DataList.Item>
-          <DataList.ItemLabel>Spatial extent</DataList.ItemLabel>
-          <DataList.ItemValue>
-            <SpatialExtent
-              bbox={collection.extent.spatial.bbox[0]}
-            ></SpatialExtent>
-          </DataList.ItemValue>
-        </DataList.Item>
+    <Stack>
+      <Value value={collection}>
+        <DataList.Root orientation={"horizontal"}>
+          {collection.extent?.spatial?.bbox?.[0] && (
+            <DataList.Item>
+              <DataList.ItemLabel>Spatial extent</DataList.ItemLabel>
+              <DataList.ItemValue>
+                <SpatialExtent
+                  bbox={collection.extent.spatial.bbox[0]}
+                ></SpatialExtent>
+              </DataList.ItemValue>
+            </DataList.Item>
+          )}
+          {collection.extent?.temporal?.interval?.[0] && (
+            <DataList.Item>
+              <DataList.ItemLabel>Temporal extent</DataList.ItemLabel>
+              <DataList.ItemValue>
+                <TemporalExtent
+                  interval={collection.extent.temporal.interval[0]}
+                ></TemporalExtent>
+              </DataList.ItemValue>
+            </DataList.Item>
+          )}
+        </DataList.Root>
+      </Value>
+      {searchLinks.length > 0 && (
+        <ItemSearch collection={collection} links={searchLinks}></ItemSearch>
       )}
-      {collection.extent?.temporal?.interval?.[0] && (
-        <DataList.Item>
-          <DataList.ItemLabel>Temporal extent</DataList.ItemLabel>
-          <DataList.ItemValue>
-            <TemporalExtent
-              interval={collection.extent.temporal.interval[0]}
-            ></TemporalExtent>
-          </DataList.ItemValue>
-        </DataList.Item>
-      )}
-    </DataList.Root>
+    </Stack>
   );
 }
 

--- a/src/components/item-collection.tsx
+++ b/src/components/item-collection.tsx
@@ -2,6 +2,7 @@ import {
   Accordion,
   createTreeCollection,
   FormatNumber,
+  SkeletonText,
   Span,
   Stack,
   Table,
@@ -11,18 +12,27 @@ import {
 import type { ReactNode } from "react";
 import { LuCircle, LuCircleDot } from "react-icons/lu";
 import useStacMap from "../hooks/stac-map";
-import type { StacGeoparquetMetadata } from "../types/stac";
+import type { StacGeoparquetMetadata, StacItemCollection } from "../types/stac";
+import Value from "./value";
 
-export default function ItemCollection() {
-  const { stacGeoparquetMetadata } = useStacMap();
+export default function ItemCollection({
+  itemCollection,
+}: {
+  itemCollection: StacItemCollection;
+}) {
+  const { isStacGeoparquet, stacGeoparquetMetadata } = useStacMap();
 
-  if (stacGeoparquetMetadata) {
-    return (
-      <StacGeoparquetInfo
-        metadata={stacGeoparquetMetadata}
-      ></StacGeoparquetInfo>
-    );
-  }
+  return (
+    <Stack>
+      <Value value={itemCollection}></Value>
+      {isStacGeoparquet &&
+        ((stacGeoparquetMetadata && (
+          <StacGeoparquetInfo
+            metadata={stacGeoparquetMetadata}
+          ></StacGeoparquetInfo>
+        )) || <SkeletonText noOfLines={3}></SkeletonText>)}
+    </Stack>
+  );
 }
 
 interface Node {

--- a/src/components/item.tsx
+++ b/src/components/item.tsx
@@ -1,6 +1,13 @@
+import { Stack } from "@chakra-ui/react";
 import type { StacItem } from "stac-ts";
 import Assets from "./assets";
+import Value from "./value";
 
 export default function Item({ item }: { item: StacItem }) {
-  return <Assets assets={item.assets}></Assets>;
+  return (
+    <Stack>
+      <Value value={item}></Value>
+      <Assets assets={item.assets}></Assets>
+    </Stack>
+  );
 }

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -46,7 +46,6 @@ export default function Map() {
     items,
     picked,
     setPicked,
-    setHref,
     stacGeoparquetTable,
     stacGeoparquetMetadata,
     setStacGeoparquetItemId,
@@ -106,12 +105,6 @@ export default function Map() {
       pickable: true,
       onClick: (info) => {
         setPicked(info.object);
-        const selfLink = info.object?.links?.find(
-          (link: { rel: string; href?: string }) => link.rel === "self",
-        );
-        if (selfLink?.href) {
-          setHref(selfLink.href);
-        }
       },
     }),
     new GeoJsonLayer({

--- a/src/components/navigation-breadcrumbs.tsx
+++ b/src/components/navigation-breadcrumbs.tsx
@@ -1,262 +1,151 @@
-import { Box, Breadcrumb, HStack, Icon, Text } from "@chakra-ui/react";
-import { useEffect, useRef, useState } from "react";
+import { Breadcrumb, HStack } from "@chakra-ui/react";
+import { useEffect, useState, type ReactNode } from "react";
 import { LuFile, LuFiles, LuFolder, LuFolderPlus } from "react-icons/lu";
-import type { StacItem } from "stac-ts";
 import useStacMap from "../hooks/stac-map";
 import type { StacValue } from "../types/stac";
-import type { IconType } from "react-icons/lib";
 
-interface BreadcrumbItem {
-  label: string;
-  href: string | null;
-  icon: IconType;
-  active: boolean;
-}
-
-export function NavigationBreadcrumbs({
-  value,
-  view,
-  setHref,
-  picked,
-  root,
-  parent,
-  collection,
-  selfHref,
-  rootHref,
-  parentHref,
-  collectionHref,
-}: {
-  value: StacValue | undefined;
-  view: string;
-  setHref: (href: string) => void;
-  picked: StacItem | undefined;
-  root: StacValue | undefined;
-  parent: StacValue | undefined;
-  collection: StacValue | undefined;
-  selfHref?: string;
-  rootHref?: string;
-  parentHref?: string;
-  collectionHref?: string;
-}) {
-  const { href } = useStacMap();
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [showEllipsis, setShowEllipsis] = useState(false);
-  const [visibleStartIndex, setVisibleStartIndex] = useState(0);
-
-  const items: BreadcrumbItem[] = [];
-
-  let rootUrl: URL | undefined;
-  let parentUrl: URL | undefined;
-  let collectionUrl: URL | undefined;
-
-  if (rootHref) {
-    try {
-      rootUrl = new URL(rootHref, selfHref);
-      if (rootUrl.toString() === selfHref) {
-        rootUrl = undefined;
-      }
-    } catch {
-      rootUrl = { toString: () => rootHref } as URL;
-    }
-  }
-
-  if (parentHref) {
-    try {
-      parentUrl = new URL(parentHref, selfHref);
-      if (
-        parentUrl.toString() === href ||
-        (rootUrl && parentUrl.toString() === rootUrl.toString())
-      ) {
-        parentUrl = undefined;
-      }
-    } catch {
-      parentUrl = { toString: () => parentHref } as URL;
-    }
-  }
-
-  if (collectionHref) {
-    try {
-      collectionUrl = new URL(collectionHref, selfHref);
-    } catch {
-      collectionUrl = { toString: () => collectionHref } as URL;
-    }
-  }
-
-  if (value?.type === "Catalog") {
-    items.push({
-      label: value.title || value.id || "Catalog",
-      href: selfHref || null,
-      icon: LuFolder,
-      active: view === "catalog",
-    });
-  } else if (value?.type === "Collection") {
-    if (rootUrl && root) {
-      items.push({
-        label: (root.title as string) || root.id || "Catalog",
-        href: rootUrl.toString(),
-        icon: LuFolder,
-        active: false,
-      });
-    } else if (parentUrl && parent && parent.type === "Catalog") {
-      items.push({
-        label: (parent.title as string) || parent.id || "Catalog",
-        href: parentUrl.toString(),
-        icon: LuFolder,
-        active: false,
-      });
-    }
-
-    items.push({
-      label: value.title || value.id || "Collection",
-      href: selfHref || null,
-      icon: LuFolderPlus,
-      active: view === "collection",
-    });
-  } else if (value?.type === "Feature") {
-    if (rootUrl && root) {
-      items.push({
-        label: (root.title as string) || root.id || "Catalog",
-        href: rootUrl.toString(),
-        icon: LuFolder,
-        active: false,
-      });
-    }
-
-    if (collectionUrl && collection) {
-      const collectionSelfHref = collection.links?.find(
-        (link: { rel: string; href?: string }) => link.rel === "self",
-      )?.href;
-      items.push({
-        label: (collection.title as string) || collection.id || "Collection",
-        href: collectionSelfHref || collectionUrl.toString(),
-        icon: LuFolderPlus,
-        active: false,
-      });
-    } else if (parentUrl && parent && parent.type === "Collection") {
-      items.push({
-        label: parent.title || parent.id || "Collection",
-        href: parentUrl.toString(),
-        icon: LuFolderPlus,
-        active: false,
-      });
-    }
-
-    items.push({
-      label: value.properties?.title || value.id || "Item",
-      href: selfHref || null,
-      icon: LuFile,
-      active: view === "item",
-    });
-  } else if (value?.type === "FeatureCollection") {
-    items.push({
-      label: "Search Results",
-      href: selfHref || null,
-      icon: LuFiles,
-      active: view === "collection",
-    });
-  }
-
-  if (view === "picked" && picked) {
-    if (items.length > 0) {
-      items.forEach((item) => (item.active = false));
-    }
-    items.push({
-      label: picked.properties?.title || picked.id || "Selected Item",
-      href: null,
-      icon: LuFile,
-      active: true,
-    });
-  }
+export function NavigationBreadcrumbs() {
+  const { value, parent, root, picked, setHref } = useStacMap()!;
+  const [breadcrumbs, setBreadcrumbs] = useState<ReactNode>();
 
   useEffect(() => {
-    const checkWidth = () => {
-      if (!containerRef.current) return;
-
-      const containerWidth = containerRef.current.offsetWidth;
-      const MAX_WIDTH = 500;
-
-      if (containerWidth > MAX_WIDTH && items.length > 2) {
-        setShowEllipsis(true);
-        // show ellipses instead of text from the beginning
-        setVisibleStartIndex(Math.max(0, items.length - 2));
-      } else {
-        setShowEllipsis(false);
-        setVisibleStartIndex(0);
+    const breadcrumbs = [];
+    if (value) {
+      if (root && !hasSameHref(root, value)) {
+        breadcrumbs.push(
+          <BreadcrumbItem
+            value={root}
+            key={"breadcrumb-root"}
+            text={"Root"}
+            setHref={setHref}
+          />,
+        );
       }
-    };
-
-    checkWidth();
-
-    const resizeObserver = new ResizeObserver(checkWidth);
-    if (containerRef.current) {
-      resizeObserver.observe(containerRef.current);
+      if (
+        parent &&
+        !hasSameHref(parent, value) &&
+        (!root || !hasSameHref(root, parent))
+      ) {
+        breadcrumbs.push(
+          <BreadcrumbItem
+            value={parent}
+            key={"breadcrumb-parent"}
+            text={"Parent"}
+            setHref={setHref}
+          />,
+        );
+      }
+      breadcrumbs.push(
+        <BreadcrumbItem
+          value={value}
+          key={"breadcrumb-value"}
+          text={getValueType(value)}
+          setHref={setHref}
+          current={!picked}
+          clearPicked={true}
+        />,
+      );
+      if (picked) {
+        breadcrumbs.push(
+          <BreadcrumbItem
+            value={picked}
+            key={"breadcrumb-picked"}
+            text={"Picked " + getValueType(picked)}
+            setHref={setHref}
+            current={true}
+          />,
+        );
+      }
     }
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, [items.length]);
-
-  const visibleItems = showEllipsis ? items.slice(visibleStartIndex) : items;
-  const hiddenItems = showEllipsis ? items.slice(0, visibleStartIndex) : [];
+    setBreadcrumbs(
+      breadcrumbs.flatMap((value, i) => [
+        value,
+        i < breadcrumbs.length - 1 && (
+          <Breadcrumb.Separator key={"separator-" + i} />
+        ),
+      ]),
+    );
+  }, [value, parent, root, picked, setHref]);
 
   return (
-    <Box ref={containerRef}>
-      <Breadcrumb.Root>
-        <Breadcrumb.List>
-          {showEllipsis && hiddenItems.length > 0 && (
-            <>
-              <Breadcrumb.Item>
-                <Breadcrumb.Ellipsis />
-              </Breadcrumb.Item>
-              <Breadcrumb.Separator />
-            </>
-          )}
-
-          {visibleItems.map((item, index) => {
-            const actualIndex = showEllipsis
-              ? index + visibleStartIndex
-              : index;
-            return (
-              <Box key={actualIndex} display="contents">
-                <Breadcrumb.Item>
-                  {item.active ? (
-                    <HStack gap={1}>
-                      <Icon size="xs" color="fg.muted">
-                        <item.icon />
-                      </Icon>
-                      <Breadcrumb.CurrentLink
-                        fontWeight="bolder"
-                        fontSize="large"
-                      >
-                        {item.label}
-                      </Breadcrumb.CurrentLink>
-                    </HStack>
-                  ) : (
-                    <Breadcrumb.Link
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        if (item.href) {
-                          setHref(item.href);
-                        }
-                      }}
-                    >
-                      <HStack gap={1}>
-                        <Icon size="xs" color="fg.muted">
-                          <item.icon />
-                        </Icon>
-                        <Text>{item.label}</Text>
-                      </HStack>
-                    </Breadcrumb.Link>
-                  )}
-                </Breadcrumb.Item>
-                {index < visibleItems.length - 1 && <Breadcrumb.Separator />}
-              </Box>
-            );
-          })}
-        </Breadcrumb.List>
-      </Breadcrumb.Root>
-    </Box>
+    <Breadcrumb.Root>
+      <Breadcrumb.List>{breadcrumbs}</Breadcrumb.List>
+    </Breadcrumb.Root>
   );
+}
+
+function BreadcrumbItem({
+  value,
+  text,
+  setHref,
+  current = false,
+  clearPicked = false,
+}: {
+  value: StacValue;
+  text: string;
+  setHref: (href: string | undefined) => void;
+  current?: boolean;
+  clearPicked?: boolean;
+}) {
+  const { setPicked } = useStacMap()!;
+  const href = value.links?.find((link) => link.rel == "self")?.href;
+  return (
+    <Breadcrumb.Item>
+      {(current && (
+        <Breadcrumb.CurrentLink>
+          <HStack>
+            {getValueIcon(value)({})}
+            {text}
+          </HStack>
+        </Breadcrumb.CurrentLink>
+      )) || (
+        <Breadcrumb.Link
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            if (clearPicked) {
+              setPicked(undefined);
+            } else if (href) {
+              setHref(href);
+            }
+          }}
+        >
+          {getValueIcon(value)({})}
+          {text}
+        </Breadcrumb.Link>
+      )}
+    </Breadcrumb.Item>
+  );
+}
+
+function getValueIcon(value: StacValue) {
+  switch (value.type) {
+    case "Catalog":
+      return LuFolder;
+    case "Collection":
+      return LuFolderPlus;
+    case "Feature":
+      return LuFile;
+    case "FeatureCollection":
+      return LuFiles;
+  }
+}
+
+function getValueType(value: StacValue) {
+  switch (value.type) {
+    case "Catalog":
+      return "Catalog";
+    case "Collection":
+      return "Collection";
+    case "Feature":
+      return "Item";
+    case "FeatureCollection":
+      return "ItemCollection";
+  }
+}
+
+function hasSameHref(a: StacValue, b: StacValue) {
+  const aHref = a.links?.find((link) => link.rel == "self")?.href;
+  const bHref = b.links?.find((link) => link.rel == "self")?.href;
+  return aHref && bHref && aHref === bHref;
 }

--- a/src/components/value.tsx
+++ b/src/components/value.tsx
@@ -1,58 +1,18 @@
-import {
-  Box,
-  Button,
-  ButtonGroup,
-  HStack,
-  Icon,
-  Image,
-  SkeletonText,
-  Stack,
-} from "@chakra-ui/react";
-import type { ReactNode } from "react";
-import {
-  LuExternalLink,
-  LuFile,
-  LuFiles,
-  LuFolder,
-  LuFolderPlus,
-} from "react-icons/lu";
+import { Button, ButtonGroup, Heading, Image, Stack } from "@chakra-ui/react";
+import { type ReactNode } from "react";
+import { LuExternalLink } from "react-icons/lu";
 import { MarkdownHooks } from "react-markdown";
 import type { StacAsset } from "stac-ts";
-import useStacMap from "../hooks/stac-map";
 import type { StacValue } from "../types/stac";
-import { Catalogs } from "./catalog";
-import { Collection, Collections } from "./collection";
-import Item from "./item";
-import ItemCollection from "./item-collection";
 import { Prose } from "./ui/prose";
 
-export default function Value({ value }: { value: StacValue }) {
-  let detail;
-  switch (value.type) {
-    case "Catalog":
-      detail = <></>;
-      break;
-    case "Collection":
-      detail = <Collection collection={value}></Collection>;
-      break;
-    case "Feature":
-      detail = <Item item={value}></Item>;
-      break;
-    case "FeatureCollection":
-      detail = <ItemCollection></ItemCollection>;
-      break;
-  }
-  return <Overview value={value}>{detail}</Overview>;
-}
-
-function Overview({
+export default function Value({
   value,
   children,
 }: {
   value: StacValue;
-  children: ReactNode;
+  children?: ReactNode;
 }) {
-  const { catalogs, collections, isFetchingCollections } = useStacMap();
   const thumbnailAsset =
     value.assets &&
     typeof value.assets === "object" &&
@@ -60,92 +20,49 @@ function Overview({
       ? (value.assets.thumbnail as StacAsset)
       : undefined;
   const selfHref = value.links?.find((link) => link.rel == "self")?.href;
-  const ValueIcon = getValueIcon(value);
-  const type = getValueType(value);
 
   return (
-    <Stack gap={4}>
-      <Stack>
-        <HStack fontSize={"xs"} fontWeight={"light"}>
-          <Icon>
-            <ValueIcon></ValueIcon>
-          </Icon>
-          {type}
-        </HStack>
+    <Stack>
+      <Heading>{(value.title as string) || value.id || value.type}</Heading>
 
-        {thumbnailAsset && (
-          <Image
-            maxH={"200px"}
-            fit={"scale-down"}
-            src={thumbnailAsset.href}
-          ></Image>
-        )}
-
-        {!!value.description && (
-          <Prose>
-            <MarkdownHooks>{value.description as string}</MarkdownHooks>
-          </Prose>
-        )}
-
-        <ButtonGroup size={"xs"} variant={"outline"}>
-          {selfHref && (
-            <>
-              <Button asChild>
-                <a href={selfHref} target="_blank">
-                  <LuExternalLink></LuExternalLink> Source
-                </a>
-              </Button>
-              <Button asChild>
-                <a
-                  href={
-                    "https://radiantearth.github.io/stac-browser/#/external/" +
-                    selfHref.replace(/^(https?:\/\/)/, "")
-                  }
-                  target="_blank"
-                >
-                  <LuExternalLink></LuExternalLink> STAC Browser
-                </a>
-              </Button>
-            </>
-          )}
-        </ButtonGroup>
-      </Stack>
-
-      <Box>{children}</Box>
-
-      {catalogs && catalogs.length > 0 && (
-        <Catalogs catalogs={catalogs}></Catalogs>
+      {thumbnailAsset && (
+        <Image
+          maxH={"200px"}
+          fit={"scale-down"}
+          src={thumbnailAsset.href}
+        ></Image>
       )}
-      {(collections && collections.length > 0 && (
-        <Collections collections={collections}></Collections>
-      )) ||
-        (isFetchingCollections && <SkeletonText noOfLines={3}></SkeletonText>)}
+
+      {!!value.description && (
+        <Prose>
+          <MarkdownHooks>{value.description as string}</MarkdownHooks>
+        </Prose>
+      )}
+
+      {children}
+
+      <ButtonGroup size={"xs"} variant={"outline"} py={4}>
+        {selfHref && (
+          <>
+            <Button asChild>
+              <a href={selfHref} target="_blank">
+                <LuExternalLink></LuExternalLink> Source
+              </a>
+            </Button>
+            <Button asChild>
+              <a
+                href={
+                  "https://radiantearth.github.io/stac-browser/#/external/" +
+                  selfHref.replace(/^(https?:\/\/)/, "")
+                }
+                target="_blank"
+              >
+                <LuExternalLink></LuExternalLink> STAC Browser
+              </a>
+            </Button>
+          </>
+        )}
+      </ButtonGroup>
     </Stack>
   );
-}
-
-function getValueIcon(value: StacValue) {
-  switch (value.type) {
-    case "Catalog":
-      return LuFolder;
-    case "Collection":
-      return LuFolderPlus;
-    case "Feature":
-      return LuFile;
-    case "FeatureCollection":
-      return LuFiles;
-  }
-}
-
-function getValueType(value: StacValue) {
-  switch (value.type) {
-    case "Catalog":
-      return "Catalog";
-    case "Collection":
-      return "Collection";
-    case "Feature":
-      return "Item";
-    case "FeatureCollection":
-      return "ItemCollection";
-  }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -15,12 +15,21 @@ interface StacMapContextType {
   /// A function to set the href.
   setHref: (href: string | undefined) => void;
 
+  /// Is the current value a stac-geoparquet?
+  isStacGeoparquet: boolean;
+
   /// A shared fileUpload structure that is the source of JSON or
   /// stac-geoparquet bytes.
   fileUpload: UseFileUploadReturn;
 
   /// The root STAC value.
   value: StacValue | undefined;
+
+  /// The root of the STAC value.
+  root: StacCatalog | StacCollection | undefined;
+
+  /// The parent of the STAC value.
+  parent: StacCatalog | StacCollection | undefined;
 
   /// Any catalogs that belong to the `value`.
   catalogs: StacCatalog[] | undefined;

--- a/src/hooks/stac-value.ts
+++ b/src/hooks/stac-value.ts
@@ -7,6 +7,7 @@ import type { StacItemCollection, StacValue } from "../types/stac";
 export default function useStacValue(
   href: string | undefined,
   fileUpload?: UseFileUploadReturn | undefined,
+  types?: ("Catalog" | "Collection" | "FeatureCollection" | "Feature")[],
 ) {
   const { db } = useDuckDb();
   const { data } = useQuery<{
@@ -24,7 +25,14 @@ export default function useStacValue(
     enabled: !!(href && db),
   });
 
-  return { value: data?.value, parquetPath: data?.parquetPath };
+  let value = data?.value;
+  if (value && types) {
+    if (!types.includes(value.type)) {
+      value = undefined;
+    }
+  }
+
+  return { value, parquetPath: data?.parquetPath };
 }
 
 async function getStacValue(

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,6 +1,6 @@
 import { useFileUpload } from "@chakra-ui/react";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import type { StacItem } from "stac-ts";
+import type { StacCatalog, StacCollection, StacItem } from "stac-ts";
 import { StacMapContext } from "./context";
 import useStacChildrenAndItems from "./hooks/stac-children-and-items";
 import useStacGeoparquet from "./hooks/stac-geoparquet";
@@ -10,6 +10,16 @@ export function StacMapProvider({ children }: { children: ReactNode }) {
   const [href, setHref] = useState<string | undefined>(getInitialHref());
   const fileUpload = useFileUpload({ maxFiles: 1 });
   const { value, parquetPath } = useStacValue(href, fileUpload);
+  const { value: root } = useStacValue(
+    value && value.links?.find((l) => l.rel === "root")?.href,
+    undefined,
+    ["Catalog", "Collection"],
+  );
+  const { value: parent } = useStacValue(
+    value && value.links?.find((l) => l.rel === "parent")?.href,
+    undefined,
+    ["Catalog", "Collection"],
+  );
   const {
     catalogs,
     collections,
@@ -130,8 +140,11 @@ export function StacMapProvider({ children }: { children: ReactNode }) {
       value={{
         href,
         setHref,
+        isStacGeoparquet: !!parquetPath,
         fileUpload,
         value,
+        parent: parent as StacCatalog | StacCollection | undefined,
+        root: root as StacCatalog | StacCollection | undefined,
         catalogs,
         collections,
         isFetchingCollections,


### PR DESCRIPTION
The titles were getting too big for our tiny little panel, so I reduced the text to just the type. I also fixed some behavior with picking/clearing from breadcrumbs.

Sidecars:

- Refactored the `Value` component a bit
- Pulled `root` and `parent` up into global state

https://github.com/user-attachments/assets/8da0fd40-5209-4fb7-9796-e25227943988

