### PR TITLE
fix: Remove fileUpload dep in useStacValue useEffect

### DIFF
--- a/src/hooks/stac-value.ts
+++ b/src/hooks/stac-value.ts
@@ -43,8 +43,7 @@ export default function useStacValue({
         setConnection(connection);
       })();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [db, href]);
+  }, [db, href, fileUpload.acceptedFiles]);
 
   const jsonResult = useQuery<StacValue | null>({
     queryKey: ["stac-value", href],


### PR DESCRIPTION
So when reviewing the error boundary PR https://github.com/developmentseed/stac-map/pull/176 which I did a couple of days ago.. apologies for not approving and bringing this up sooner but I realized the app looked like it was infinitely rendering.. Is this supposed to happen?? If not, I went down a path trying to figure out where this was happening. It looked like the `useStacValue` hook's useEffect had a dep `fileUpload` which is hook from chakra that was causing this. 

This PR just removes that dep to stop the app from infinitely rendering. But maybe this could be solved another way? Either way, I dont think this should cause a big issue having that missing dep as I think it will still be stable enough. What do you think @gadomski?

--------------------
**Behavior before (infinite render):**

https://github.com/user-attachments/assets/d895a717-b039-4cf6-a59c-c963f7a2ee44

**Behavior now:**

https://github.com/user-attachments/assets/0dcda900-f47b-4485-9b35-663a71e13222

