### PR TITLE
feat: added kyfromabove api to the examples

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,11 @@ export const EXAMPLES = [
     href: "https://raw.githubusercontent.com/developmentseed/labs-375-stac-geoparquet-backend/refs/heads/main/data/naip.parquet",
   },
   {
+    title: "Kentucky Imagery & Elevation",
+    badge: "API",
+    href: "https://spved5ihrl.execute-api.us-west-2.amazonaws.com/",
+  },
+  {
     title: "Simple item",
     badge: "item",
     href: "https://raw.githubusercontent.com/radiantearth/stac-spec/refs/heads/master/examples/simple-item.json",


### PR DESCRIPTION
I added Kentucky's STAC API as an example to the `src/contants.ts` file.  I think it adds variety and another state to complement the *Colorado NAIP*.   It might make the list too long, so I won't be upset if you don't want to include.  

```json
  {
    title: "Kentucky Imagery & Elevation",
    badge: "API",
    href: "https://spved5ihrl.execute-api.us-west-2.amazonaws.com/",
  },
```

<img width="292" height="347" alt="image" src="https://github.com/user-attachments/assets/e23eca7a-3f29-4485-bcc9-b5c3a9741b3c" />


## Checklist

- [x] Code is formatted (`yarn format`)
- [x] Code is linted (`yarn lint`)
- [x] Code builds (`yarn build`)
- [x] Tests pass (`yarn test`)
- [ ] Commit messages and/or this PR's title are formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
