### PR TITLE
fix: Check bbox value for list of lists

### DIFF
--- a/src/layers/map.tsx
+++ b/src/layers/map.tsx
@@ -266,7 +266,9 @@ function valueToGeoJson(value: StacValue) {
 function getCollectionExtents(collection: StacCollection): SpatialExtent {
   const spatialExtent = collection.extent?.spatial;
   // check if bbox is a list of lists, otherwise its a single list of nums
-  return Array.isArray(spatialExtent?.bbox?.[0]) ? spatialExtent?.bbox[0] : ((spatialExtent?.bbox as unknown) as SpatialExtent);
+  return Array.isArray(spatialExtent?.bbox?.[0])
+    ? spatialExtent?.bbox[0]
+    : (spatialExtent?.bbox as unknown as SpatialExtent);
 }
 
 function getBbox(


### PR DESCRIPTION
https://github.com/developmentseed/stac-map/issues/180

For specific collection example reported in bug ticket (https://www.eodms-sgdot.nrcan-rncan.gc.ca/stac/collections/rcm-ard) => spatial extent looks like ```  "extent": {
    "spatial": {
      "bbox": [-180, -90, 180, 90]
    },``` when I believe its supposed to be a list of lists `  "extent": {
    "spatial": {
      "bbox": [[-180, -90, 180, 90]]
    },` so change checks for that or just returns list value.

