### PR TITLE
fix: only render BitmapLayer if data are available

### DIFF
--- a/src/layers/map.tsx
+++ b/src/layers/map.tsx
@@ -103,17 +103,21 @@ export default function Map({
           `https://titiler.xyz/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=${cogTileHref}`,
         renderSubLayers: (props) => {
           const { boundingBox } = props.tile;
+          const { data, ...otherProps } = props;
 
-          return new BitmapLayer(props, {
-            data: undefined,
-            image: props.data,
-            bounds: [
-              boundingBox[0][0],
-              boundingBox[0][1],
-              boundingBox[1][0],
-              boundingBox[1][1],
-            ],
-          });
+          if (data) {
+            return new BitmapLayer(otherProps, {
+              image: data,
+              bounds: [
+                boundingBox[0][0],
+                boundingBox[0][1],
+                boundingBox[1][0],
+                boundingBox[1][1],
+              ],
+            });
+          } else {
+            return null;
+          }
         },
       })
     );


### PR DESCRIPTION
Closes #210 

This is kind of a hard one to reproduce on-demand, so you might have to just trust that I saw this get fixed (I think) #frontendproblems

Here's the preview link to the href used in the bug report: http://ds-preview-stac-map-211.s3-website-us-west-2.amazonaws.com/?href=https://maxar-opendata.s3.amazonaws.com/events/Cyclone-Senyar-Indonesia-Nov-2025/ard/acquisition_collections/102001011DCD2700_collection.json

## Checklist

- [x] Code is formatted (`yarn format`)
- [x] Code is linted (`yarn lint`)
- [x] Code builds (`yarn build`)
- [x] Tests pass (`yarn test`)
- [x] Commit messages and/or this PR's title are formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
