### PR TITLE
fix: more permissive geotiff visualization

### DIFF
--- a/src/components/cards/asset.tsx
+++ b/src/components/cards/asset.tsx
@@ -12,7 +12,7 @@ import {
   Span,
 } from "@chakra-ui/react";
 import type { StacAsset } from "stac-ts";
-import { isCog, isVisual } from "../../utils/stac";
+import { isGeoTiff } from "../../utils/stac";
 import Properties from "../sections/properties";
 
 export default function AssetCard({
@@ -62,7 +62,7 @@ export default function AssetCard({
           </Collapsible.Root>
         )}
         <HStack>
-          {isCog(asset) && isVisual(asset) && (
+          {isGeoTiff(asset) && (
             <Checkbox.Root
               checked={checked}
               onCheckedChange={(e) => {
@@ -75,9 +75,7 @@ export default function AssetCard({
               <Checkbox.Label>Visualize</Checkbox.Label>
             </Checkbox.Root>
           )}
-
           <Span flex={"1"} />
-
           <ButtonGroup size="sm" variant="outline">
             <Button asChild>
               <a href={asset.href} target="_blank">

--- a/src/utils/stac.ts
+++ b/src/utils/stac.ts
@@ -251,10 +251,8 @@ export function getImportantLinks(links: StacLink[]) {
   return { rootLink, collectionsLink, nextLink, prevLink, filteredLinks };
 }
 
-export function isCog(asset: StacAsset) {
-  return (
-    asset.type === "image/tiff; application=geotiff; profile=cloud-optimized"
-  );
+export function isGeoTiff(asset: StacAsset) {
+  return asset.type?.startsWith("image/tiff; application=geotiff");
 }
 
 export function isVisual(asset: StacAsset) {
@@ -273,8 +271,8 @@ export function getCogTileHref(value: StacValue): string | undefined {
     return undefined;
   }
 
-  for (const asset of Object.values(value.assets)) {
-    if (isCog(asset) && isVisual(asset)) {
+  for (const [key, asset] of Object.entries(value.assets)) {
+    if (isGeoTiff(asset) && (isVisual(asset) || key === "visual")) {
       return asset.href as string;
     }
   }


### PR DESCRIPTION
Closes #230 

<img width="3024" height="1720" alt="image" src="https://github.com/user-attachments/assets/ae1aae22-1003-44d8-a75d-1fcf8fe696f9" />


## Checklist

- [x] Code is formatted (`yarn format`)
- [x] Code is linted (`yarn lint`)
- [x] Code builds (`yarn build`)
- [x] Tests pass (`yarn test`)
- [x] Commit messages and/or this PR's title are formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
