### PR TITLE
revert: remove plausible analytics snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.png" />
     <title>stac-map</title>
-    <script
-      defer
-      data-domain="developmentseed.org"
-      src="https://plausible.io/js/script.js"
-    ></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Undo the recently added Plausible script include in stac-map while we pause this analytics direction.

Apologies, I missed that Plausible has a consolidated site feature now. We'll use that and revert back to the old tracking method.


## Checklist

- [ ] Code is formatted (`yarn format`)
- [ ] Code is linted (`yarn lint`)
- [ ] Code builds (`yarn build`)
- [ ] Tests pass (`yarn test`)
- [ ] Commit messages and/or this PR's title are formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
