### PR TITLE
chore: add plausible analytics for stac-map

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.png" />
     <title>stac-map</title>
-    <script async src="https://plausible.io/js/pa-GVTHZhFPjzeY-YszhgOBs.js"></script>
+    <script
+      async
+      src="https://plausible.io/js/pa-GVTHZhFPjzeY-YszhgOBs.js"
+    ></script>
     <script>
-      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-      plausible.init()
+      ((window.plausible =
+        window.plausible ||
+        function () {
+          (plausible.q = plausible.q || []).push(arguments);
+        }),
+        (plausible.init =
+          plausible.init ||
+          function (i) {
+            plausible.o = i || {};
+          }));
+      plausible.init();
     </script>
   </head>
   <body>


### PR DESCRIPTION
Agh! @gadomski Sorry for all the back and forth. I moved too quickly through all the pages. For stac-map, instead of removing the script today I should have just changed the domain. I added "stac-map" [as a site in Plausible](https://plausible.io/stac-map/) and changed the configuration here to match.


## Checklist

- [ ] Code is formatted (`yarn format`)
- [ ] Code is linted (`yarn lint`)
- [ ] Code builds (`yarn build`)
- [ ] Tests pass (`yarn test`)
- [ ] Commit messages and/or this PR's title are formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
