### PR TITLE
Allow loading custom html at runtime for styling + arbitrary maplibre layers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,25 @@ VITE_STAC_NATURAL_QUERY_API=https://api.stac-semantic-search.k8s.labs.ds.io
 # Base URL for STAC Browser external links
 # Default: https://radiantearth.github.io/stac-browser/#/external/
 VITE_STAC_BROWSER_URL="https://radiantearth.github.io/stac-browser/#/external/"
+
+# ---------------------------------------------------------------------------
+# White-label / branding (all optional, all baked in at build time)
+# ---------------------------------------------------------------------------
+
+# CSS classes added to <html> (e.g. for class-based theme libraries)
+# VITE_HTML_CLASSES=
+
+# Arbitrary HTML injected at end of <head> (stylesheet links, import maps, module scripts)
+# VITE_HEAD_INJECT=
+
+# HTML injected before <div id="root"> (e.g. a custom header web component)
+# VITE_BODY_PREPEND=
+
+# HTML injected after <div id="root"> (e.g. scripts to configure custom elements via JS)
+# VITE_BODY_APPEND=
+
+# Height of the custom header as a CSS length (e.g. 64px). Shrinks map/overlay to fit.
+# VITE_HEADER_HEIGHT=64px
+
+# URL to a JSON array of MapLibre layer definitions to load on startup. See docs/customization.md.
+# VITE_EXTRA_LAYERS_URL=https://example.com/layers.json

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 tests/**/__screenshots__/
 codebook.toml
 .env
+
+# Additional layers file (user modified)
+public/layers.json

--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ VITE_DEFAULT_HREF=https://my-stac-api.com
 
 Then run `yarn build` and deploy the `dist/` directory to your static hosting provider.
 For an example of white-labeling **stac-map**, see https://github.com/gadomski/eoapi.stac-map.io.
+
+For advanced customisation - custom headers, branding, and extra map layers - see [docs/customization.md](./docs/customization.md).

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,0 +1,60 @@
+# Customization
+
+White-label configuration is done via environment variables set before `yarn build`. See `.env.example` for the full list.
+
+## Custom header
+
+Four build-time variables let you inject a custom header element above the app:
+
+| Variable             | What it injects |
+| -------------------- | --------------- |
+| `VITE_HTML_CLASSES`  | CSS classes on `<html>` |
+| `VITE_HEAD_INJECT`   | HTML at end of `<head>` — stylesheet links, import maps, module scripts, inline `<style>` |
+| `VITE_BODY_PREPEND`  | HTML before `<div id="root">` — your header element |
+| `VITE_BODY_APPEND`   | HTML after `<div id="root">` — scripts to configure custom elements (e.g. setting `.tabs` via JS, since functions can't be HTML attributes) |
+| `VITE_HEADER_HEIGHT` | CSS length (e.g. `64px`). Sets `--header-height` on `:root` and shrinks the map/overlay to fit below the header. |
+
+### Example
+
+```shell
+VITE_BASE_PATH=/
+VITE_DEFAULT_HREF=https://my-stac-api.com
+VITE_HEADER_HEIGHT=64px
+VITE_HTML_CLASSES=my-theme-light
+VITE_HEAD_INJECT='<link rel="stylesheet" href="https://cdn.example.com/theme.css" /><script type="module" src="https://cdn.example.com/my-header.js"></script>'
+VITE_BODY_PREPEND='<my-header id="app-header" title="My STAC App"></my-header>'
+VITE_BODY_APPEND="<script>document.getElementById('app-header').tabs=[{label:'Home',href:'/'}];</script>"
+```
+
+### Quoting
+
+Always quote `VITE_HEAD_INJECT`, `VITE_BODY_PREPEND`, and `VITE_BODY_APPEND`. Unquoted values are truncated at `#`, silently breaking any inline CSS with hex colors.
+
+- Use **single quotes** when the HTML uses double-quoted attributes (the common case)
+- Use **double quotes** if the value contains single quotes (e.g. inline JS strings)
+- Keep values on one line — multiline values work locally but break in most CI environments
+
+## Extra map layers
+
+Set `VITE_EXTRA_LAYERS_URL` to a JSON file defining MapLibre layers to load on startup. The file is fetched after the map initialises and does not block rendering. It can live in `public/` or on any CORS-enabled URL.
+
+The JSON is an array of MapLibre layer objects with an inline `source`. All source types are supported (`raster`, `vector`, `geojson`), including PMTiles via `pmtiles://` URLs.
+
+```json
+[
+  {
+    "id": "my-coverage",
+    "type": "fill",
+    "source": {
+      "type": "vector",
+      "url": "pmtiles://https://example.com/coverage.pmtiles"
+    },
+    "source-layer": "layer-name",
+    "filter": ["==", ["geometry-type"], "Polygon"],
+    "paint": {
+      "fill-color": "#d43f3f",
+      "fill-opacity": 0.2
+    }
+  }
+]
+```

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "maplibre-gl": "^5.24.0",
     "next-themes": "^0.4.3",
     "oidc-client-ts": "^3.5.0",
+    "pmtiles": "^4.4.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-error-boundary": "^6.1.1",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -63,7 +63,7 @@ export default function App() {
 
   return (
     <>
-      <Box h={"100dvh"}>
+      <Box h={"calc(100dvh - var(--header-height, 0px))"}>
         <FileUpload.Root
           unstyled={true}
           onFileAccept={(details) => {
@@ -79,7 +79,7 @@ export default function App() {
           <FileUpload.Dropzone
             disableClick={true}
             style={{
-              height: "100dvh",
+              height: "calc(100dvh - var(--header-height, 0px))",
               width: "100dvw",
             }}
           >

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -15,7 +15,9 @@ import {
 } from "@geoarrow/deck.gl-layers";
 import bbox from "@turf/bbox";
 import type { Feature, FeatureCollection } from "geojson";
+import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
+import { Protocol } from "pmtiles";
 import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 import {
   Layer as MaplibreLayer,
@@ -27,11 +29,27 @@ import {
 import { useColorModeValue } from "../components/ui/color-mode";
 import { useStore } from "../store";
 
+const pmtilesProtocol = new Protocol();
+maplibregl.addProtocol("pmtiles", pmtilesProtocol.tile.bind(pmtilesProtocol));
+
 type Color = [number, number, number, number];
+
+interface ExtraLayerConfig {
+  id: string;
+  type: string;
+  "source-layer"?: string;
+  source: { type: string; [key: string]: unknown };
+  paint?: Record<string, unknown>;
+  layout?: Record<string, unknown>;
+  filter?: unknown[];
+  minzoom?: number;
+  maxzoom?: number;
+}
 
 export default function Map() {
   const mapRef = useRef<MapRef>(null);
   const [isLoaded, setIsLoaded] = useState(false);
+  const [extraLayers, setExtraLayers] = useState<ExtraLayerConfig[]>([]);
   const mapStyle = useColorModeValue(
     "positron-gl-style",
     "dark-matter-gl-style"
@@ -94,6 +112,15 @@ export default function Map() {
     if (mapRef?.current && value && isLoaded)
       fitBounds(mapRef.current, value, collections);
   }, [value, collections, isLoaded]);
+
+  useEffect(() => {
+    const url = import.meta.env.VITE_EXTRA_LAYERS_URL;
+    if (!url || !isLoaded) return;
+    fetch(url)
+      .then((r) => r.json())
+      .then((data) => setExtraLayers(data))
+      .catch((e) => console.warn("stac-map: failed to load extra layers", e));
+  }, [isLoaded]);
 
   const layers: Layer[] = [
     new GeoJsonLayer({
@@ -307,6 +334,23 @@ export default function Map() {
           <MaplibreLayer id="web-map-link-layer-wmts" type="raster" />
         </Source>
       )}
+      {extraLayers.map((layer) => {
+        const { type: sourceType, ...sourceProps } = layer.source;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { source, ...layerSpec } = layer;
+        return (
+          <Source
+            key={layer.id}
+            id={`extra-${layer.id}`}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            type={sourceType as any}
+            {...sourceProps}
+          >
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+            <MaplibreLayer {...(layerSpec as any)} />
+          </Source>
+        );
+      })}
       <DeckGLOverlay
         layers={layers}
         getCursor={(props) => getCursor(mapRef, props)}

--- a/src/components/overlay.tsx
+++ b/src/components/overlay.tsx
@@ -7,10 +7,10 @@ export default function Overlay() {
     <Container
       zIndex={1}
       fluid
-      h="100dvh"
+      h="calc(100dvh - var(--header-height, 0px))"
       pointerEvents={"none"}
       position={"absolute"}
-      top={0}
+      top="var(--header-height, 0px)"
       left={0}
       pt={4}
     >

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_STAC_BROWSER_URL?: string;
   readonly VITE_STAC_NATURAL_QUERY_API?: string;
+  readonly VITE_EXTRA_LAYERS_URL?: string;
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,69 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv, type Plugin } from "vite";
 import topLevelAwait from "vite-plugin-top-level-await";
 import wasm from "vite-plugin-wasm";
 
 // https://vite.dev/config/
-export default defineConfig({
-  base: process.env.VITE_BASE_PATH || "/stac-map/",
-  build: {
-    target: "esnext",
-  },
-  resolve: {
-    tsconfigPaths: true,
-  },
-  worker: {
-    format: "es",
-  },
-  plugins: [react(), wasm(), topLevelAwait()],
+export default defineConfig(({ mode }) => {
+  // Merge .env file variables with shell environment (shell takes precedence)
+  const env = { ...loadEnv(mode, process.cwd(), ""), ...process.env };
+
+  function whitelabelPlugin(): Plugin {
+    return {
+      name: "stac-map-whitelabel",
+      transformIndexHtml(html) {
+        const htmlClasses = env.VITE_HTML_CLASSES;
+        const headInject = env.VITE_HEAD_INJECT;
+        const bodyPrepend = env.VITE_BODY_PREPEND;
+        const bodyAppend = env.VITE_BODY_APPEND;
+        const headerHeight = env.VITE_HEADER_HEIGHT;
+
+        if (htmlClasses) {
+          html = html.replace("<html", `<html class="${htmlClasses}"`);
+        }
+
+        // Inject early so the variable is available before any external CSS loads
+        if (headerHeight) {
+          html = html.replace(
+            "<head>",
+            `<head>\n    <style>:root { --header-height: ${headerHeight}; }</style>`,
+          );
+        }
+
+        if (headInject) {
+          html = html.replace("</head>", `  ${headInject}\n  </head>`);
+        }
+
+        if (bodyPrepend) {
+          html = html.replace(
+            '<div id="root">',
+            `${bodyPrepend}\n    <div id="root">`,
+          );
+        }
+
+        if (bodyAppend) {
+          html = html.replace(
+            '<div id="root"></div>',
+            `<div id="root"></div>\n    ${bodyAppend}`,
+          );
+        }
+
+        return html;
+      },
+    };
+  }
+
+  return {
+    base: env.VITE_BASE_PATH || "/stac-map/",
+    build: {
+      target: "esnext",
+    },
+    resolve: {
+      tsconfigPaths: true,
+    },
+    worker: {
+      format: "es",
+    },
+    plugins: [react(), wasm(), topLevelAwait(), whitelabelPlugin()],
+  };
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5000,6 +5000,11 @@ fflate@0.7.4:
   resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.4.tgz#61587e5d958fdabb5a9368a302c25363f4f69f50"
   integrity sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==
 
+fflate@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -7298,6 +7303,13 @@ playwright@^1.59.1:
     playwright-core "1.59.1"
   optionalDependencies:
     fsevents "2.3.2"
+
+pmtiles@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/pmtiles/-/pmtiles-4.4.1.tgz#11ecb2a01453ba7c0ce88027e15f768aba18913b"
+  integrity sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==
+  dependencies:
+    fflate "^0.8.2"
 
 pngjs@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
## White-label deployments: styling env vars & custom map layers

Long time coming, but I finally took a look at this.

Love this project. I **really** want to use stac-map as the new OpenAerialMap frontend.

Needs to make a few tweaks to allow custom styling + map layers.

Closes #138 Closes #137

Extends the existing `VITE_*` white-label system with 6 new env vars, so deployers can fully brand their stac-map instance:
- Adding custom header with logo / links
- Theme CSS
- Pre-configured map layers

I wanted to do all this without forking the repo (and contribute upstream as much as possible going forward)

Assisted by: Opus 4.6 LLM for brainstorming and review.

---

### How it works

- New `whitelabelPlugin` in `vite.config.ts` Vite `transformIndexHtml` hook.
- The values are read from the env at build time and injected directly into `index.html`.
- Additional env var `VITE_EXTRA_LAYERS_URL` is used to fetch a remote maplibre style at runtime (or bundled under ./public). It's async and non-blocking.

---

### New vars

Build vars:

- `VITE_HTML_CLASSES` - CSS classes added to `<html>` (e.g. for theme libraries)
- `VITE_HEAD_INJECT` - arbitrary HTML injected at end of `<head>` (stylesheet links, import maps, module scripts)
- `VITE_BODY_PREPEND` - HTML injected before `<div id="root">` (your header element)
- `VITE_BODY_APPEND` - HTML injected after `<div id="root">` (JS to configure custom elements whose properties can't be set as HTML attributes)
- `VITE_HEADER_HEIGHT` - CSS length (e.g. `64px`); sets `--header-height` on `:root` and shrinks the map/overlay to fit below the header

Runtime var:

- `VITE_EXTRA_LAYERS_URL` - URL to maplibre layer JSON. Supports raster, vector, GeoJSON, and PMTiles (`pmtiles://`) sources

---

### Example: adding a web component header

```shell
# .env
VITE_BASE_PATH=/
VITE_DEFAULT_HREF=https://my-stac-api.com
VITE_HEADER_HEIGHT=64px
VITE_HTML_CLASSES=my-theme-light

VITE_HEAD_INJECT=<link rel="stylesheet" href="https://cdn.example.com/theme.css" /><script type="module" src="https://cdn.example.com/my-header.js"></script>
VITE_BODY_PREPEND=<my-header id="app-header" title="My STAC App"></my-header>
VITE_BODY_APPEND=<script>document.getElementById('app-header').tabs=[{label:'Docs',href:'https://docs.example.com'}];</script>
VITE_EXTRA_LAYERS_URL=/layers.json
```

`public/layers.json` - PMTiles vector source for OpenAerialMap global coverage:

```json
[
  {
    "id": "oam-global-coverage",
    "type": "fill",
    "source": {
      "type": "vector",
      "url": "pmtiles://https://s3.amazonaws.com/oin-hotosm-temp/global-coverage.pmtiles"
    },
    "source-layer": "globalcoverage",
    "minzoom": 0,
    "maxzoom": 15,
    "filter": ["==", ["geometry-type"], "Polygon"],
    "paint": {
      "fill-color": "#d43f3f",
      "fill-opacity": 0.2,
      "fill-outline-color": "#d43f3f"
    }
  }
]
```

### New dependency

- I added the `pmtiles` dependency for registering in maplibre.
- This allows loading files with protocol `pmtiles://`.

---

The resulting app running looks like this:

<img width="1998" height="1581" alt="image" src="https://github.com/user-attachments/assets/adcd30bd-0cc1-4bc1-9ae4-840a58671fdd" />

1. Custom header
2. Global coverage layer loaded
3. OAM STAC loaded at startup

## Checklist

- [x] Code is formatted (`yarn format`)
- [x] Code is linted (`yarn lint`)
- [x] Code builds (`yarn build`)
- [x] Tests pass (`yarn test`)
- [x] Commit messages and/or this PR's title are formatted per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
