### PR TITLE
fix: relative heights for app

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -11,7 +11,7 @@ import { ErrorBoundaryAlert } from "./ui/error-alert";
 
 function MapFallback({ error }: { error: unknown }) {
   return (
-    <AbsoluteCenter h="100dvh%" w="100dvw">
+    <AbsoluteCenter h="100%" w="100%">
       <Center maxW={"40%"}>
         <ErrorBoundaryAlert context="map component" error={error} />
       </Center>
@@ -52,7 +52,7 @@ export default function App({
 
   return (
     <>
-      <Box h={"100dvh"}>
+      <Box h={"100%"} w={"100%"}>
         <FileUpload.Root
           unstyled={true}
           onFileAccept={(details) => {
@@ -63,15 +63,11 @@ export default function App({
             });
           }}
           disabled={!db}
+          h={"100%"}
+          w={"100%"}
         >
           <FileUpload.HiddenInput />
-          <FileUpload.Dropzone
-            disableClick={true}
-            style={{
-              height: "100dvh",
-              width: "100dvw",
-            }}
-          >
+          <FileUpload.Dropzone disableClick={true} h={"100%"} w={"100%"}>
             <ErrorBoundary FallbackComponent={MapFallback}>
               <Map extraLayers={extraLayers} />
             </ErrorBoundary>

--- a/src/components/overlay.tsx
+++ b/src/components/overlay.tsx
@@ -7,7 +7,7 @@ export default function Overlay() {
     <Container
       zIndex={1}
       fluid
-      h="100dvh"
+      h="100%"
       pointerEvents={"none"}
       position={"absolute"}
       top={0}

--- a/src/components/stac-map.tsx
+++ b/src/components/stac-map.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   ChakraProvider,
   defaultSystem,
   type SystemContext,
@@ -105,15 +106,17 @@ export function StacMap({
   return (
     <ChakraProvider value={chakraSystem ?? defaultSystem}>
       <ColorModeProvider {...colorMode}>
-        {auth ? (
-          <AuthProvider {...auth}>
-            <OidcTokenSync>
-              <LoginSplash>{inner}</LoginSplash>
-            </OidcTokenSync>
-          </AuthProvider>
-        ) : (
-          inner
-        )}
+        <Box position="relative" h="100%" w="100%" overflow="hidden">
+          {auth ? (
+            <AuthProvider {...auth}>
+              <OidcTokenSync>
+                <LoginSplash>{inner}</LoginSplash>
+              </OidcTokenSync>
+            </AuthProvider>
+          ) : (
+            inner
+          )}
+        </Box>
       </ColorModeProvider>
     </ChakraProvider>
   );

--- a/src/components/stac-map.tsx
+++ b/src/components/stac-map.tsx
@@ -48,6 +48,12 @@ export interface StacMapProps {
   footer?: ReactNode;
   /** Source and layer information for extra maplibre layers */
   extraLayers?: ExtraLayerProps[];
+  /**
+   * Skip the internal `ChakraProvider` and `ColorModeProvider`. Use when the
+   * host app already mounts its own Chakra v3 system and `next-themes`
+   * provider; the `chakraSystem` and `colorMode` props are ignored when true.
+   */
+  disableChakraProvider?: boolean;
 }
 
 let mountCount = 0;
@@ -67,6 +73,7 @@ export function StacMap({
   stacBrowserUrl,
   footer,
   extraLayers,
+  disableChakraProvider = false,
 }: StacMapProps) {
   useEffect(() => {
     mountCount += 1;
@@ -103,21 +110,27 @@ export function StacMap({
     </QueryClientProvider>
   );
 
+  const wrapped = (
+    <Box position="relative" h="100%" w="100%" overflow="hidden">
+      {auth ? (
+        <AuthProvider {...auth}>
+          <OidcTokenSync>
+            <LoginSplash>{inner}</LoginSplash>
+          </OidcTokenSync>
+        </AuthProvider>
+      ) : (
+        inner
+      )}
+    </Box>
+  );
+
+  if (disableChakraProvider) {
+    return wrapped;
+  }
+
   return (
     <ChakraProvider value={chakraSystem ?? defaultSystem}>
-      <ColorModeProvider {...colorMode}>
-        <Box position="relative" h="100%" w="100%" overflow="hidden">
-          {auth ? (
-            <AuthProvider {...auth}>
-              <OidcTokenSync>
-                <LoginSplash>{inner}</LoginSplash>
-              </OidcTokenSync>
-            </AuthProvider>
-          ) : (
-            inner
-          )}
-        </Box>
-      </ColorModeProvider>
+      <ColorModeProvider {...colorMode}>{wrapped}</ColorModeProvider>
     </ChakraProvider>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,11 @@ import { version } from "../package.json";
 import Footer from "./components/footer";
 import { StacMap, type StacMapProps } from "./components/stac-map";
 
+const rootStyle = {
+  height: "100dvh",
+  width: "100dvw",
+} as const;
+
 const authority = import.meta.env.VITE_AUTH_AUTHORITY as string | undefined;
 const clientId = import.meta.env.VITE_AUTH_CLIENT_ID as string | undefined;
 
@@ -34,11 +39,13 @@ const stacBrowserUrl = import.meta.env.VITE_STAC_BROWSER_URL as
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <StacMap
-      defaultHref={defaultHref}
-      auth={auth}
-      stacBrowserUrl={stacBrowserUrl}
-      footer={<Footer version={version} changelog={changelog} />}
-    />
+    <div style={rootStyle}>
+      <StacMap
+        defaultHref={defaultHref}
+        auth={auth}
+        stacBrowserUrl={stacBrowserUrl}
+        footer={<Footer version={version} changelog={changelog} />}
+      />
+    </div>
   </StrictMode>
 );


### PR DESCRIPTION
This lets any caller put anything around the component they want, including a custom header or footer. Also adds the ability to disable the chakra provider, in case you have your own.